### PR TITLE
I think I have solved the problem of spectra being regenerated repeat…

### DIFF
--- a/xga/sources/base.py
+++ b/xga/sources/base.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (david.turner@sussex.ac.uk) 02/02/2022, 14:27. Copyright (c) The Contributors
+#  Last modified by David J Turner (david.turner@sussex.ac.uk) 20/02/2022, 12:37. Copyright (c) The Contributors
 
 import os
 import pickle
@@ -723,7 +723,7 @@ class BaseSource:
 
                     # I split the 'spec' part of the end of the name of the spectrum, and can use the parts of the
                     #  file name preceding it to search for matching arf/rmf files
-                    sp_info_str = sp.split('_spec')[0]
+                    sp_info_str = cur_d + sp.split('/')[-1].split('_spec')[0]
 
                     # Fairly self explanatory, need to find all the separate products needed to define an XGA
                     #  spectrum


### PR DESCRIPTION
…edly, it was because of a simple splitting path problem, not accounting for the fact that higher up path names could have _spec in them. I think this should solve issue #691

With Vio's tests in her branches it seems that this problem has been fixed now