### PR TITLE
Added the entropy sourcetools submodule into the sourcetools.rst file…

### DIFF
--- a/docs/source/xga.sourcetools.rst
+++ b/docs/source/xga.sourcetools.rst
@@ -17,6 +17,14 @@ sourcetools.temperature module
    :undoc-members:
    :show-inheritance:
 
+sourcetools.entropy module
+--------------------------
+
+.. automodule:: xga.sourcetools.entropy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 sourcetools.mass module
 --------------------------
 


### PR DESCRIPTION
… - it should show up in the docs now.