### PR TITLE
Update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,3 +23,4 @@ docutils==0.17
 ipympl>=0.9.1
 exceptiongroup~=1.1.0
 urllib3<2.0.0
+jinja2<3.1


### PR DESCRIPTION
Added jinja2<3.1 to the documentation requirements, so that the readthedocs build will succeed