### PR TITLE
Update docs requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx==8.1.3
 nbsphinx
 sphinx_rtd_theme
 ipython


### PR DESCRIPTION
Set a required Sphinx version for the documentation builds - as there is some incompatibility with the latest version of Sphinx that readthedocs now defaults to.