### PR TITLE
Should have fixed the tiny issue when reading regions - if there is o…

### DIFF
--- a/xga/sources/base.py
+++ b/xga/sources/base.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 12/08/2024, 11:43. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 11/03/2025, 21:00. Copyright (c) The Contributors
 
 import os
 import pickle
@@ -1327,6 +1327,9 @@ class BaseSource:
                 #  TODO see issue #908, figure out how to support different resolutions of image
                 try:
                     ims = self.get_images(obs_id)
+                    # Make sure that the return is in a list
+                    if not isinstance(ims, list):
+                        ims = [ims]
                 except NoProductAvailableError:
                     raise NoProductAvailableError("There is no image available for observation {o}, associated "
                                                   "with {n}. An image is currently required to check for sky "


### PR DESCRIPTION
…nly one image read in from disk then get_images would return an image rather than a list, and as images can't be indexed Python gets upset.