### PR TITLE
Moved the XSPEC template script's check for a minimum number of noticed channels to before model declaration

### DIFF
--- a/xga/__init__.py
+++ b/xga/__init__.py
@@ -1,10 +1,10 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 16/07/2025, 12:25. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:20. Copyright (c) The Contributors
 from . import _version
 __version__ = _version.get_versions()['version']
 
 from .utils import (xga_conf, CENSUS, OUTPUT, NUM_CORES, XGA_EXTRACT, BASE_XSPEC_SCRIPT, MODEL_PARS,
-    MODEL_UNITS, ABUND_TABLES, XSPEC_FIT_METHOD, COUNTRATE_CONV_SCRIPT, NHC, BLACKLIST, HY_MASS, MEAN_MOL_WEIGHT,
-    SAS_VERSION, XSPEC_VERSION, SAS_AVAIL, DEFAULT_COSMO, TELESCOPES, USABLE, DEFAULT_TELE_SEARCH_DIST, COMBINED_INSTS,
-    eSASS_AVAIL, SRC_REGION_COLOURS, check_telescope_choices, PRETTY_TELESCOPE_NAMES, CIAO_AVAIL, CIAO_VERSION, CALDB_AVAIL,
-    CALDB_VERSION, ESASS_VERSION, RAD_MATCH_PRECISION)
+                    MODEL_UNITS, ABUND_TABLES, XSPEC_FIT_METHOD, COUNTRATE_CONV_SCRIPT, NHC, BLACKLIST, HY_MASS, MEAN_MOL_WEIGHT,
+                    SAS_VERSION, XSPEC_VERSION, SAS_AVAIL, DEFAULT_COSMO, TELESCOPES, USABLE, DEFAULT_TELE_SEARCH_DIST, COMBINED_INSTS,
+                    ESASS_AVAIL, SRC_REGION_COLOURS, check_telescope_choices, PRETTY_TELESCOPE_NAMES, CIAO_AVAIL, CIAO_VERSION, CALDB_AVAIL,
+                    CALDB_VERSION, ESASS_VERSION, RAD_MATCH_PRECISION)

--- a/xga/generate/ciao/spec.py
+++ b/xga/generate/ciao/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 26/03/2025, 10:57. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from copy import copy
@@ -45,6 +45,15 @@ def _chandra_spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Uni
     :param bool disable_progress: Setting this to true will turn off the CIAO generation progress bar.
     :param bool force_gen: This boolean flag will force the regeneration of spectra, even if they already exist.
     """
+
+    # Early XGA could generate spectra within the detection regions of the source, but
+    #  that has been deprecated for quite a while, as it was a bad idea. The generation
+    #  of spectra within user-specified regions will be possible, but it will be
+    #  implemented differently. The original way was bad because the detection region
+    #  could/almost certainly would be different for each observation
+    if outer_radius == 'region':
+        raise ValueError("The string 'region' is no longer a valid option for "
+                         "the 'outer_radius' argument.")
 
     stack = False  # This tells the ciao_call routine that this command won't be part of a stack.
     execute = True  # This should be executed immediately.

--- a/xga/generate/common.py
+++ b/xga/generate/common.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 08/12/2025, 21:40. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:39. Copyright (c) The Contributors
 
 import os
 import sys
@@ -60,11 +60,11 @@ def execute_cmd(cmd: str, p_type: Union[str, List[str]], p_path: list, extra_inf
 
     # Write the standard out to a log file
     with open(std_out_file, "w") as std_outo:
-        std_outo.write(out)
+        std_outo.write(cmd + "\n\n" + out)
     # If there are standard error entries, write them to a file as well
     if len(err) > 0:
         with open(std_err_file, "w") as std_erro:
-            std_erro.write(err)
+            std_erro.write(cmd + "\n\n" + err)
 
     # Trying to make sure that any passed arrays get smoothed out into the list type we want
     if type(p_path) == np.ndarray:

--- a/xga/generate/common.py
+++ b/xga/generate/common.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 08/07/2025, 17:26. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 08/12/2025, 21:40. Copyright (c) The Contributors
 
 import os
 import sys
@@ -45,9 +45,26 @@ def execute_cmd(cmd: str, p_type: Union[str, List[str]], p_path: list, extra_inf
         if "DYLD_LIBRARY_PATH" in sys_env:
             cmd = f"export DYLD_LIBRARY_PATH={sys_env['DYLD_LIBRARY_PATH']} && {cmd}"
 
+    # This runs the passed command - it captures the stdout and stderr as well
     out, err = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+    # Captured out/err are byte type, will decode that into str for easier use
     out = out.decode("UTF-8", errors='ignore')
     err = err.decode("UTF-8", errors='ignore')
+
+    # We will assume that the first entry in the product path argument is the
+    #  primary output file, and will name the log files after it
+    log_stem = p_path[0][:p_path[0].rfind('.')]
+    # One file for out and one for error
+    std_out_file = log_stem + "_stdout.log"
+    std_err_file = log_stem + "_stderr.log"
+
+    # Write the standard out to a log file
+    with open(std_out_file, "w") as std_outo:
+        std_outo.write(out)
+    # If there are standard error entries, write them to a file as well
+    if len(err) > 0:
+        with open(std_err_file, "w") as std_erro:
+            std_erro.write(err)
 
     # Trying to make sure that any passed arrays get smoothed out into the list type we want
     if type(p_path) == np.ndarray:

--- a/xga/generate/esass/_common.py
+++ b/xga/generate/esass/_common.py
@@ -1,0 +1,7 @@
+#  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 11:57. Copyright (c) The Contributors
+
+from astropy.units import Quantity
+
+EROSITA_EXTMAP_LO_EN = Quantity(0.2, 'keV')
+EROSITA_EXTMAP_HI_EN = Quantity(10.0, 'keV')

--- a/xga/generate/esass/lightcurve.py
+++ b/xga/generate/esass/lightcurve.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 03/07/2025, 10:55. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy
@@ -190,6 +190,15 @@ def _lc_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, Qu
                             "lo_en": lo_en,
                             "hi_en": hi_en,
                             "telescope": 'erosita'})
+
+    # Early XGA could generate spectra within the detection regions of the source, but
+    #  that has been deprecated for quite a while, as it was a bad idea. The generation
+    #  of spectra within user-specified regions will be possible, but it will be
+    #  implemented differently. The original way was bad because the detection region
+    #  could/almost certainly would be different for each observation
+    if outer_radius == 'region':
+        raise ValueError("The string 'region' is no longer a valid option for "
+                         "the 'outer_radius' argument.")
 
     # We check to see whether there is an eROSITA entry in the 'telescopes' property. If sources is a Source
     #  object, then that property contains the telescopes associated with that source, and if it is a Sample object

--- a/xga/generate/esass/run.py
+++ b/xga/generate/esass/run.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 08/07/2025, 10:05. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:20. Copyright (c) The Contributors
 
 from functools import wraps
 from multiprocessing.dummy import Pool
@@ -9,7 +9,7 @@ from warnings import warn
 from tqdm import tqdm
 
 from ..common import execute_cmd
-from ... import eSASS_AVAIL
+from ... import ESASS_AVAIL
 from ...exceptions import eSASSNotFoundError, ProductGenerationError
 from ...products import BaseProduct, AnnularSpectra
 from ...samples.base import BaseSample
@@ -27,7 +27,7 @@ def esass_call(esass_func):
     @wraps(esass_func)
     def wrapper(*args, **kwargs):
         # Checking eSASS is installed and available on the system
-        if not eSASS_AVAIL:
+        if not ESASS_AVAIL:
             raise eSASSNotFoundError("No eSASS installation has been found on this machine.")
 
         # The first argument of all of these eSASS functions will be the source object (or a list of),

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,24 +1,25 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:47. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
 from random import randint
-from shutil import rmtree
 from typing import Union, List
 from warnings import warn
 
 import numpy as np
 from astropy.units import Quantity
 
+from ._common import EROSITA_EXTMAP_LO_EN, EROSITA_EXTMAP_HI_EN
 from .misc import evtool_combine_evts
 from .phot import evtool_image
 from .run import esass_call
 from ..common import get_annular_esass_region
 from ..sas._common import region_setup
 from ... import OUTPUT, NUM_CORES, ESASS_VERSION
-from ...exceptions import eROSITAImplentationError, eSASSInputInvalid, NoProductAvailableError, \
+from ...exceptions import eSASSInputInvalid, NoProductAvailableError, \
     TelescopeNotAssociatedError
+from ...products.misc import EventList
 from ...samples.base import BaseSample
 from ...sources import BaseSource, ExtendedSource, GalaxyCluster
 
@@ -52,34 +53,52 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     :param float min_counts: If generating a grouped spectrum, this is the minimum number of counts per channel.
         To disable minimum counts set this parameter to None.
     :param float min_sn: If generating a grouped spectrum, this is the minimum signal-to-noise in each channel.
-        To disable minimum signal-to-noise set this parameter to None.
+        To disable minimum signal-to-noise, set this parameter to None.
     :param float min_sn: If generating a grouped spectrum, this is the minimum signal-to-noise in each channel.
-        To disable minimum signal-to-noise set this parameter to None.
+        To disable minimum signal-to-noise, set this parameter to None.
     :param int num_cores: The number of cores to use, default is set to 90% of available.
     :param bool disable_progress: Setting this to true will turn off the eSASS generation progress bar.
     :param bool combine_tm: Create spectra for individual ObsIDs that are a combination of the data from all the
-        telescope modules utilized for that ObsID. This can help to offset the low signal-to-noise nature of the
+        telescope modules used for that ObsID. This can help to offset the low signal-to-noise nature of the
         survey data eROSITA takes. Default is True.
     :param bool combine_obs: Setting this to False will generate an image for each associated observation, 
         instead of for one combined observation.
     :param bool force_gen: This boolean flag will force the regeneration of spectra, even if they already exist.
     """
 
-    def _append_spec_info(cur_evt_list):
+    def _make_spec_cmd_info(cur_evt_list: EventList):
         """
-        Internal method to get the parameters required for the srctool spectral generation command.
+        Internal function to get prepare the commands required to generate spectra
+        from eROSITA observations. This functions acts on a single event list at a time.
+        Output final file paths and extra information dictionaries are also
+        created and returned.
+
+        :param EventList cur_evt_list: The event list to generate spectra from.
+        :return: A list of spectral generation commands, a list of final spectrum file
+            paths, and a list of dictionaries of extra information.
+        :rtype: Tuple[List[str], List[str], List[str]]
         """
 
         # Then we have to account for the two different modes this function can be used in - generating spectra
         #  for individual telescope models, or generating a single stacked spectrum for all telescope modules
+        # TODO NEED TO MAKE SURE THE RIGHT TMs ARE BEING USED HERE
         if combine_tm:
             inst_names = ['combined']
-            inst_nums = ['"' + ' '.join([tm[-1] for tm in list(source.num_inst_obs['erosita'].keys())]) + '"']
+            inst_nums = ['"' + ' '.join([tm[-1] for tm in list(source.num_inst_obs[cur_evt_list.telescope].keys())]) + '"']
             inst_srctool_id = ['0']
         else:
-            inst_names = deepcopy(list(source.num_inst_obs['erosita'].keys()))
-            inst_nums = [tm[-1] for tm in list(source.num_inst_obs['erosita'].keys())]
+            inst_names = deepcopy(list(source.num_inst_obs[cur_evt_list.telescope].keys()))
+            inst_nums = [tm[-1] for tm in list(source.num_inst_obs[cur_evt_list.telescope].keys())]
             inst_srctool_id = inst_nums
+
+        # Mirroring some of the variables in the name space above, this is where we
+        #  will store commands, final paths, etc. that originate from the
+        #  currently passed event lists. They will be passed out of this function, and
+        #  will always be a list even for a 'combined' generation where only one
+        #  iteration of the for loop will occur
+        cur_cmds = []
+        cur_fin_paths = []
+        cur_ex_info = []
 
         for inst_ind, inst in enumerate(inst_names):
             # Extracting just the instrument number for later use in eSASS commands (or indeed a list of instrument
@@ -87,15 +106,15 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             inst_no = inst_nums[inst_ind]
 
             try:
-                if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
+                if use_combine_obs and (len(source.obs_ids[cur_evt_list.telescope]) > 1):
                     check_sp = source.get_combined_spectra(outer_radii[s_ind], inst, inner_radii[s_ind], group_spec,
-                                                           min_counts, min_sn, telescope='erosita')
+                                                           min_counts, min_sn, telescope=cur_evt_list.telescope)
 
                 else:
                     # Got to check if this spectrum already exists
                     check_sp = source.get_spectra(outer_radii[s_ind], cur_evt_list.obs_id, inst, inner_radii[s_ind],
                                                   group_spec,
-                                                  min_counts, min_sn, telescope='erosita')
+                                                  min_counts, min_sn, telescope=cur_evt_list.telescope)
                 exists = True
 
             except NoProductAvailableError:
@@ -117,68 +136,53 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                      stacklevel=2)
                 t_step = t_step_survey
 
-            # setting up file names for output files
-            if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
-                # The files produced by this function will now be stored in the combined directory.
-                final_dest_dir = OUTPUT + "erosita/combined/"
-                rand_ident = randint(0, 100_000_000)
-                # Makes absolutely sure that the random integer hasn't already been used
-                while len([f for f in os.listdir(final_dest_dir)
-                           if str(rand_ident) in f.split(OUTPUT + "erosita/combined/")[-1]]) != 0:
-                    rand_ident = randint(0, 100_000_000)
+            # The following code will set up the path and file names for output files,
+            #  with the first step involving the creation of temporary directories.
+            # First, we define the path to the directory where our generated products
+            #  are going to live at the end of the process.
+            final_dest_dir = os.path.join(OUTPUT, cur_evt_list.telescope,
+                                          cur_evt_list.obs_id)
 
-                dest_dir = os.path.join(final_dest_dir, "temp_srctool_{}".format(rand_ident))
-
-            else:
-                # Sets up working directory, adding a random number so that parallel processes can't clash.
-                # The temporary region files necessary to generate eROSITA spectra (if contaminating sources are
-                #  being removed) will be written to a different temporary folder using the same random identifier.
-                rand_ident = randint(0, 100_000_000)
-                dest_dir = OUTPUT + "erosita/" + "{o}/{i}_{n}_temp_{r}/".format(o=cur_evt_list.obs_id, i=inst,
-                                                                                n=source.name,
-                                                                                r=rand_ident)
-            # If something got interrupted and the temp directory still exists, and it somehow has the same
-            #  random number, this will remove it
-            if os.path.exists(dest_dir):
-                rmtree(dest_dir)
+            # Generate a random number to use as a unique addition to the working
+            #  directory name - ensures there won't be any clashes
+            rand_ident = randint(0, 100_000_000)
+            # This is the name of the working directory for the generation process
+            ddir_name = "temp_srctool_{i}_{r}".format(i=inst, r=randint(0, 100_000_000))
+            # And the full path
+            dest_dir = os.path.join(final_dest_dir, ddir_name)
 
             # The temporary directory is made, and we also set up a symlink to the relevant event list - this is
             #  to help fix issue #1400. We found that event list paths over 204 characters long cause errors when
             #  trying to generate spectra for eROSITA (eSASS4DR1)
-            os.mkdir(dest_dir)
+            os.makedirs(dest_dir, exist_ok=True)
             # The temporary directory will now have a symlink to the relevant event list, with the symlink name
             #  the same as the actual event list
             os.symlink(cur_evt_list.path, os.path.join(dest_dir, os.path.basename(cur_evt_list.path)))
 
-            # If there is no match to a region, the source region returned by this method will be None,
-            #  and if the user wants to generate spectra from region files, we have to ignore that observations
-            if outer_radius == "region" and source.source_back_regions("erosita", "region", cur_evt_list.obs_id)[
-                0] is None:
-                raise eROSITAImplentationError("XGA for eROSITA does not support the outer_radius='region' "
-                                               "argument.")
+            # This constructs the eSASS strings/region files
+            reg = get_annular_esass_region(source,
+                                           src_inn_rad,
+                                           src_out_rad,
+                                           cur_evt_list.obs_id,
+                                           interloper_regions=interloper_regions,
+                                           central_coord=source.default_coord,
+                                           rand_ident=rand_ident)
+            b_reg = get_annular_esass_region(source,
+                                             bck_inn_rad,
+                                             bck_out_rad,
+                                             cur_evt_list.obs_id,
+                                             interloper_regions=back_inter_reg,
+                                             central_coord=source.default_coord,
+                                             bkg_reg=True,
+                                             rand_ident=rand_ident)
 
-            # Because the region will be different for each ObsID, I have to call the setup function here
-            if outer_radius == 'region':
-                raise eROSITAImplentationError("XGA for eROSITA does not support the outer_radius='region' "
-                                               "argument.")
+            # Set up a string describing the central coordinate in addition to the regions
+            coord_str = "icrs;{ra},{dec}".format(ra=source.default_coord[0].value,
+                                                 dec=source.default_coord[1].value)
 
-            else:
-                # This constructs the eSASS strings/region files for any radius that isn't 'region'
-                reg = get_annular_esass_region(source, inner_radii[s_ind], outer_radii[s_ind], cur_evt_list.obs_id,
-                                               interloper_regions=interloper_regions,
-                                               central_coord=source.default_coord, rand_ident=rand_ident)
-                b_reg = get_annular_esass_region(source, outer_radii[s_ind] * source.background_radius_factors[0],
-                                                 outer_radii[s_ind] * source.background_radius_factors[1],
-                                                 cur_evt_list.obs_id,
-                                                 interloper_regions=back_inter_reg,
-                                                 central_coord=source.default_coord, bkg_reg=True,
-                                                 rand_ident=rand_ident)
-                inn_rad_degrees = inner_radii[s_ind]
-                out_rad_degrees = outer_radii[s_ind]
-
-                # TODO implement the detector map
-                # This creates a detection map for the source and background region
-                # map_path = _det_map_creation(outer_radii[s_ind], source, cur_evt_list.obs_id, inst)
+            # TODO implement the detector map
+            # This creates a detection map for the source and background region
+            # map_path = _det_map_creation(outer_radii[s_ind], source, cur_evt_list.obs_id, inst)
 
             # Setting up file names that include the extra variables
             if group_spec and min_counts is not None:
@@ -186,79 +190,54 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             else:
                 extra_file_name = ''
 
-            # Cannot control the naming of spectra from srctool, so need to store
-            # the XGA formatting of the spectra, so that they can be renamed 
-            # TODO put issue, renaming spectra
-            # TODO TIDY THIS UP, THE STORAGE NAMES OF THE SPECTRA ARE ALREADY DEFINED
-            # The names of spectra will be different depending on if it is from a combined eventlist
-            if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
-                prefix = str(rand_ident) + '_{i}_'.format(i=inst) + '{n}_'.format(n=source.name)
+            # Cannot control the naming of spectra from srctool. However, we will
+            #  define our desired output file names here and move the files output by
+            #  srctool to the correct file names at the end of the process.
+            # The names of output files will be different depending on if they
+            #  are from a combined event list.
+            if use_combine_obs and (len(source.obs_ids[cur_evt_list.telescope]) > 1):
+                prefix = str(rand_ident) + '_{i}_{n}_'.format(i=inst, n=source.name)
             else:
-                prefix = "{o}_{i}_{n}_".format(o=cur_evt_list.obs_id, i=inst, n=source.name)
+                prefix = "{o}_{i}_{n}_".format(o=cur_evt_list.obs_id,
+                                               i=inst,
+                                               n=source.name)
 
-            spec_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_spec.fits"
-            spec_str = prefix + spec_str
-            rmf_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}.rmf"
-            rmf_str = prefix + rmf_str
-            arf_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}.arf"
-            arf_str = prefix + arf_str
-            b_spec_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_backspec.fits"
-            b_spec_str = prefix + b_spec_str
-            b_rmf_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_backspec.rmf"
-            b_rmf_str = prefix + b_rmf_str
-            b_arf_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_backspec.arf"
-            b_arf_str = prefix + b_arf_str
+            # Format for the name of the spectrum file
+            spec_str = prefix + "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_spec.fits"
 
             # Naming the non-grouped spectra
             no_grp_spec_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}{ex}_spec_not_grouped.fits"
             no_grp_spec_str = prefix + no_grp_spec_str
             no_grp_spec = no_grp_spec_str.format(ra=source.default_coord[0].value,
-                                                 dec=source.default_coord[1].value, ri=src_inn_rad_str,
-                                                 ro=src_out_rad_str, ex=extra_file_name)
+                                                 dec=source.default_coord[1].value,
+                                                 ri=src_inn_rad.value,
+                                                 ro=src_out_rad.value,
+                                                 ex=extra_file_name)
 
-            # Making the strings of the XGA formatted names that we will rename the outputs of srctool to
+            # Creating the XGA formatted names we'll move srctool outputs to
             spec = spec_str.format(ra=source.default_coord[0].value,
-                                   dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                   ex=extra_file_name, gr=group_spec)
+                                   dec=source.default_coord[1].value,
+                                   ri=src_inn_rad.value,
+                                   ro=src_out_rad.value,
+                                   ex=extra_file_name,
+                                   gr=group_spec)
 
-            rmf = rmf_str.format(ra=source.default_coord[0].value,
-                                 dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                 ex=extra_file_name, gr=group_spec)
-            arf = arf_str.format(ra=source.default_coord[0].value,
-                                 dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                 ex=extra_file_name, gr=group_spec)
+            # The RMF and ARF files can be named by replacing the '_spec.fits' part of
+            #  the grouped spectrum file name with '.rmf' and '.arf' respectively.
+            rmf = spec.replace("_spec.fits", '.rmf')
+            arf = spec.replace("_spec.fits", '.arf')
 
-            b_spec = b_spec_str.format(ra=source.default_coord[0].value,
-                                       dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                       ex=extra_file_name, gr=group_spec)
-            b_rmf = b_rmf_str.format(ra=source.default_coord[0].value,
-                                     dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                     ex=extra_file_name, gr=group_spec)
-            b_arf = b_arf_str.format(ra=source.default_coord[0].value,
-                                     dec=source.default_coord[1].value, ri=src_inn_rad_str, ro=src_out_rad_str,
-                                     ex=extra_file_name, gr=group_spec)
+            # The background spectrum file name can also be constructed by replacing
+            #  part of the source spectrum file name. This is possible because the
+            #  inner and outer radii in the background spec file name match the
+            #  source region size, rather than the background region size
+            b_spec = spec.replace("_spec.fits", "_backspec.fits")
 
-            # These file names are for the debug images of the source and background images, they will not be loaded
-            #  in as a XGA products, but exist purely to check by eye if necessary
-            dim = "{o}_{i}_{n}_ra{ra}_dec{dec}_ri{ri}_ro{ro}_debug.fits".format(o=cur_evt_list.obs_id, i=inst,
-                                                                                n=source.name,
-                                                                                ra=source.default_coord[0].value,
-                                                                                dec=source.default_coord[1].value,
-                                                                                ri=src_inn_rad_str,
-                                                                                ro=src_out_rad_str)
-            b_dim = ("{o}_{i}_{n}_ra{ra}_dec{dec}_ri{ri}_ro{ro}_"
-                     "back_debug.fits").format(o=cur_evt_list.obs_id, i=inst, n=source.name,
-                                               ra=source.default_coord[0].value,
-                                               dec=source.default_coord[1].value, ri=src_inn_rad_str,
-                                               ro=src_out_rad_str)
+            # Then the ARF/RMF file paths for the backspec are modified versions of
+            #  the background spectrum file path
+            b_rmf = b_spec.replace("_backspec.fits", ".rmf")
+            b_arf = b_spec.replace("_backspec.fits", ".arf")
 
-            # TODO ADD MANY MORE COMMENTS
-            coord_str = "icrs;{ra}, {dec}".format(ra=source.default_coord[0].value,
-                                                  dec=source.default_coord[1].value)
-            src_reg_str = reg  # dealt with in get_annular_esass_region
-
-            # TODO allow user to chose tstep and xgrid
-            bsrc_reg_str = b_reg
             # Defining the grouping keywords
             if group_spec and min_counts is not None:
                 group_type = 'min'
@@ -273,44 +252,83 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # Fills out the srctool command to make the main and background spectra
             # WE NOTE THAT, BECAUSE WE CREATE EVENT LIST SYMLINKS TO SOLVE ISSUE #1400, THE EVENT LIST PATHS
             #  ARE JUST THE BASE FILENAME OF THE EVENT LIST
-            if isinstance(source, ExtendedSource):
-                try:
-                    if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
-                        im = source.get_combined_images(lo_en=Quantity(0.2, 'keV'), hi_en=Quantity(10.0, 'keV'),
-                                                        telescope='erosita')
-                    else:
-                        # We only need the image path for extended source generation
-                        im = source.get_images(cur_evt_list.obs_id, lo_en=Quantity(0.2, 'keV'),
-                                               hi_en=Quantity(10.0, 'keV'),
-                                               telescope='erosita')
-                    # We have a slightly different command for extended and point sources
-                    s_cmd_str = ext_srctool_cmd.format(d=dest_dir, ef=os.path.basename(cur_evt_list.path), sc=coord_str,
-                                                       reg=src_reg_str, i=inst_no, ts=t_step, em=im.path, et=et)
-                except:
-                    raise ValueError(f"it was this sources {source.name}")
+            if extended_src:
+                # For extended source we're going to pass an image to act as an extent map, and
+                #  now have to retrieve the relevant image path.
+                # We made sure that the images we need have been generated in the
+                #  setup steps of the _spec_cmds function
+                if use_combine_obs and (len(source.obs_ids[evt_list.telescope]) > 1):
+                    im = source.get_combined_images(lo_en=EROSITA_EXTMAP_LO_EN,
+                                                    hi_en=EROSITA_EXTMAP_HI_EN,
+                                                    telescope=evt_list.telescope)
+                else:
+                    # We only need the image path for extended source generation
+                    im = source.get_images(cur_evt_list.obs_id,
+                                           lo_en=EROSITA_EXTMAP_LO_EN,
+                                           hi_en=EROSITA_EXTMAP_HI_EN,
+                                           telescope=evt_list.telescope)
+
+                # As with the paths to the event lists, it is possible that the image
+                #  file names will be too long for eSASS' srctool to handle. To
+                #  mitigate the potential problem, we make another symlink
+                os.symlink(im.path, os.path.join(dest_dir, os.path.basename(im.path)))
+
+                # Fill out the spectrum generation (srctool) command specific to extended sources
+                s_cmd_str = ext_sp_cmd.format(d=dest_dir,
+                                              ef=os.path.basename(cur_evt_list.path),
+                                              sc=coord_str,
+                                              reg=reg,
+                                              i=inst_no,
+                                              ts=t_step,
+                                              em=os.path.basename(im.path),
+                                              et=ext_type)
 
             else:
-                s_cmd_str = pnt_srctool_cmd.format(d=dest_dir, ef=os.path.basename(cur_evt_list.path), sc=coord_str,
-                                                   reg=src_reg_str, i=inst_no, ts=t_step)
+                # We have a slightly different command for extended and point sources
+                s_cmd_str = pnt_sp_cmd.format(d=dest_dir,
+                                              ef=os.path.basename(cur_evt_list.path),
+                                              sc=coord_str,
+                                              reg=reg,
+                                              i=inst_no,
+                                              ts=t_step)
 
             # TODO FIGURE OUT WHAT TO DO ABOUT THE TIMESTEP
-            sb_cmd_str = bckgr_srctool_cmd.format(ef=os.path.basename(cur_evt_list.path), sc=coord_str,
-                                                  breg=bsrc_reg_str,
-                                                  i=inst_no, ts=t_step * 4)
+            sb_cmd_str = back_sp_cmd.format(ef=os.path.basename(cur_evt_list.path),
+                                            sc=coord_str,
+                                            breg=b_reg,
+                                            i=inst_no,
+                                            ts=t_step * 4)
             # Filling out the grouping command
-            grp_cmd_str = grp_cmd.format(infi=no_grp_spec, of=spec, gt=group_type, gs=group_scale)
+            grp_cmd_str = grp_cmd.format(infi=no_grp_spec,
+                                         of=spec,
+                                         gt=group_type,
+                                         gs=group_scale)
 
+            # The instrument ID we need to rename the output files in this case
             rename_srctool_id = inst_srctool_id[inst_ind]
-            # Occupying the rename command for all the outputs of srctool
+            # Adding rename commands for all the outputs of srctool
+            #  Start with grouped spectra, because that is an optional output and has
+            #  to have an if-else
             if group_spec:
-                rename_spec = rename_cmd.format(i_no=rename_srctool_id, type='SourceSpec', nn=no_grp_spec)
+                rename_spec = rename_cmd.format(i_no=rename_srctool_id,
+                                                type='SourceSpec',
+                                                nn=no_grp_spec)
             else:
-                rename_spec = rename_cmd.format(i_no=rename_srctool_id, type='SourceSpec', nn=spec)
+                rename_spec = rename_cmd.format(i_no=rename_srctool_id,
+                                                type='SourceSpec',
+                                                nn=spec)
+            # Then set up the rename commands for everything else!
             rename_rmf = rename_cmd.format(i_no=rename_srctool_id, type='RMF', nn=rmf)
             rename_arf = rename_cmd.format(i_no=rename_srctool_id, type='ARF', nn=arf)
-            rename_b_spec = rename_cmd.format(i_no=rename_srctool_id, type='SourceSpec', nn=b_spec)
-            rename_b_rmf = rename_cmd.format(i_no=rename_srctool_id, type='RMF', nn=b_rmf)
-            rename_b_arf = rename_cmd.format(i_no=rename_srctool_id, type='ARF', nn=b_arf)
+            rename_b_spec = rename_cmd.format(i_no=rename_srctool_id,
+                                              type='SourceSpec',
+                                              nn=b_spec)
+            rename_b_rmf = rename_cmd.format(i_no=rename_srctool_id,
+                                             type='RMF',
+                                             nn=b_rmf)
+            rename_b_arf = rename_cmd.format(i_no=rename_srctool_id,
+                                             type='ARF',
+                                             nn=b_arf)
 
             # TODO I think all of this needs to made clearer, and each command should have a ; on the end by
             #  default perhaps - or at least it should be consistent
@@ -335,7 +353,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             #  we'll neaten it up at some point
             cmd_str += ';'
 
-            # Removing the 'merged spectra' output of srctool, the background in this case
+            # Removing the 'merged spectra' output of srctool, for the background spectra in this case
             if combine_tm:
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
                                      remove_all_but_merged_cmd])
@@ -350,38 +368,44 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                         # Remove "TM8" output otherwise
                         cmd_str += f";{remove_merged_dr1_8}"
 
-            # If the user wants to group the spectra then this command should be added
+            # If the user wants to group the spectrum then this command should be added
             if group_spec:
-                # This both performs the grouping, and deletes the original non-grouped file. A similar effect
+                # This both performs the grouping and deletes the original non-grouped file. A similar effect
                 #  could be ensured by turning clobber on for ftgrouppha, but I think this way is safer. That way
-                #  if grouping fails there definitely won't be a file with the name of the grouped spectrum, but
+                #  if grouping fails, there definitely won't be a file with the name of the grouped spectrum, but
                 #  no grouping applied.
                 cmd_str += "; " + grp_cmd_str
 
-            # Adds clean up commands to move all generated files and remove temporary directory
+            # Adds clean up commands to move all generated files and remove the temporary directory
             cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
             # If temporary region files were made, they will be here
-            if os.path.exists(OUTPUT + 'erosita/' + cur_evt_list.obs_id + '/temp_regs_{i}'.format(i=rand_ident)):
+            if os.path.exists(final_dest_dir + '/temp_regs_{i}'.format(i=rand_ident)):
                 # Removing this directory
                 cmd_str += ";rm -r temp_regs_{i}".format(i=rand_ident)
 
-            cmds.append(cmd_str)  # Adds the full command to the set
+            # Adds the full command to set of commands originating from the currently
+            #  passed event list
+            cur_cmds.append(cmd_str)
+            # Same for the final output paths, and extra info dictionary
+            cur_fin_paths.append(os.path.join(final_dest_dir, spec))
+            cur_ex_info.append({"inner_radius": src_inn_rad,
+                                "outer_radius": src_out_rad,
+                                "rmf_path": os.path.join(final_dest_dir, rmf),
+                                "arf_path": os.path.join(final_dest_dir, arf),
+                                "b_spec_path": os.path.join(final_dest_dir, b_spec),
+                                "b_rmf_path": os.path.join(final_dest_dir, b_rmf),
+                                "b_arf_path": os.path.join(final_dest_dir, b_arf),
+                                "obs_id": cur_evt_list.obs_id,
+                                "instrument": inst,
+                                "central_coord": source.default_coord,
+                                "grouped": group_spec,
+                                "min_counts": min_counts,
+                                "min_sn": min_sn,
+                                "over_sample": None,
+                                "from_region": False,
+                                "telescope": cur_evt_list.telescope})
+        return cur_cmds, cur_fin_paths, cur_ex_info
 
-            final_paths.append(os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, spec))
-            extra_info.append({"inner_radius": inn_rad_degrees, "outer_radius": out_rad_degrees,
-                               "rmf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, rmf),
-                               "arf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, arf),
-                               "b_spec_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_spec),
-                               "b_rmf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_rmf),
-                               "b_arf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_arf),
-                               "obs_id": cur_evt_list.obs_id, "instrument": inst,
-                               "central_coord": source.default_coord,
-                               "grouped": group_spec,
-                               "min_counts": min_counts,
-                               "min_sn": min_sn,
-                               "over_sample": None,
-                               "from_region": from_region,
-                               "telescope": "erosita"})
 
     # Early XGA could generate spectra within the detection regions of the source, but
     #  that has been deprecated for quite a while, as it was a bad idea. The generation
@@ -394,6 +418,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
     # TODO This will change in a future release, so that the user can control it - see issue #1113. The definitions
     #  are up the top of the function as a reminder
+    # TODO allow user to chose tstep and xgrid
     t_step_survey = 0.5
     t_step_point = 100
 
@@ -401,8 +426,8 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     #  object, then that property contains the telescopes associated with that source, and if it is a Sample object
     #  then 'telescopes' contains the list of unique telescopes that are associated with at least one member source.
     # Clearly if eROSITA isn't associated at all, then continuing with this function would be pointless
-    if ((not isinstance(sources, list) and 'erosita' not in sources.telescopes) or
-            (isinstance(sources, list) and 'erosita' not in sources[0].telescopes)):
+    if ((not isinstance(sources, list) and ('erosita' not in sources.telescopes and 'erass' not in sources.telescopes)) or
+            (isinstance(sources, list) and ('erosita' not in sources[0].telescopes and 'erass' not in sources[0].telescopes))):
         raise TelescopeNotAssociatedError("There are no eROSITA data associated with the source/sample, as such "
                                           "eROSITA spectra cannot be generated.")
 
@@ -410,17 +435,19 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     if isinstance(sources, BaseSource):
         sources = [sources]
 
+    # In this case the user wants to combine separate sky tiles, so we have to make
+    #  sure that combined event lists exist for each source
     if combine_obs:
         # This requires combined event lists - this function will generate them
         evtool_combine_evts(sources)
 
-    if outer_radius != 'region':
-        from_region = False
-        # TODO edit region_setup to be telescope agnostic
-        sources, inner_radii, outer_radii = region_setup(sources, outer_radius, inner_radius, disable_progress, '')
-    else:
-        # This is used in the extra information dictionary for when the XGA spectrum object is defined
-        from_region = True
+    # TODO edit region_setup to be telescope agnostic
+    sources, inner_radii, outer_radii = region_setup(sources,
+                                                     outer_radius,
+                                                     inner_radius,
+                                                     disable_progress,
+                                                     obs_id='',
+                                                     num_cores=NUM_CORES)
 
     # Making sure this value is the expected type
     if min_counts is not None:
@@ -428,7 +455,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     if min_sn is not None:
         min_sn = float(min_sn)
 
-    # Checking user has passed a grouping argument if group spec is true
+    # Checking that the user has passed a grouping argument if group_spec is True
     if all([o is not None for o in [min_counts, min_sn]]):
         raise eSASSInputInvalid("Only one grouping option can passed, you can't group both by"
                                 " minimum counts AND by minimum signal to noise.")
@@ -445,41 +472,38 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     else:
         extra_name = ''
 
-    # eSASS' srctool operates quite differently for extended sources and point sources. We are going to want a
+    # eSASS's srctool operates quite differently for extended sources and point sources. We are going to want a
     #  detector map for extended sources to weight the ARF calculation, so here we check the source type
     if isinstance(sources[0], (ExtendedSource, GalaxyCluster)):
-        ex_src = True
-        if combine_obs:
-            evtool_image(sources, Quantity(0.2, 'keV'), Quantity(10, 'keV'), combine_obs=True, num_cores=NUM_CORES)
-        else:
-            # TODO Decide if this will stay or not - it might be terribly inefficient using the whole thing for this
-            evtool_image(sources, Quantity(0.2, 'keV'), Quantity(10, 'keV'), num_cores=NUM_CORES)
-        # Sets the psf type to MAP, which means we'll be using an image to encode the emission extent
-        et = 'MAP'
-    else:
-        ex_src = False
-        et = 'POINT'
+        # Set up a boolean value to tell us later on if this is an extended source
+        extended_src = True
 
-    # TODO implement the det map EXTTPYE, at the moment this spectrum will treat the target as a point source
-    # Defining the various eSASS commands that need to be populated
-    # There will be a different command for extended and point sources
-    # ext_srctool_cmd = ('cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" todo="SPEC ARF RMF" srcreg="{reg}" '
-    #                    'backreg=NONE tstep={ts} insts={i} psftype=NONE')
+        # Sets the extent model type to MAP, which means we'll be using an image to encode the emission extent
+        ext_type = 'MAP'
+
+        # Ensures that the images we intend to use as extent maps have actually been generated
+        evtool_image(sources, EROSITA_EXTMAP_LO_EN, EROSITA_EXTMAP_HI_EN, combine_obs=combine_obs, num_cores=NUM_CORES)
+    else:
+        # Set up a boolean value to tell us later on if this is a point source
+        extended_src = False
+        ext_type = 'POINT'
 
     # TODO PATTERN AND FLAG SELECTION - REALLY NEED TO INCLUDE THAT
+    # Defining the various eSASS commands that need to be populated
+    # There will be a different command for extended and point sources
+    ext_sp_cmd = 'cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" ' \
+                 'todo="SPEC ARF RMF" srcreg="{reg}" backreg=NONE tstep={ts} ' \
+                 'insts={i} psftype=NONE extmap="{em}" exttype="MAP"'
 
-    ext_srctool_cmd = ('cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" todo="SPEC ARF RMF" srcreg="{reg}" '
-                       'backreg=NONE tstep={ts} insts={i} psftype=NONE extmap="{em}" exttype="MAP"')
-
-    # For extended sources, it is best to make a background spectra with a separate command
-    bckgr_srctool_cmd = 'srctool eventfiles="{ef}" srccoord="{sc}" todo="SPEC ARF RMF"' \
-                        ' srcreg="{breg}" backreg=NONE insts={i}' \
-                        ' tstep={ts} psftype=NONE'
+    # For extended sources, it is best to make a background spectrum with a separate command
+    back_sp_cmd = 'srctool eventfiles="{ef}" srccoord="{sc}" todo="SPEC ARF RMF" ' \
+                  'srcreg="{breg}" backreg=NONE insts={i} ' \
+                  'tstep={ts} psftype=NONE'
 
     # TODO check the point source command in esass with some EDR obs
-    pnt_srctool_cmd = 'cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" todo="SPEC ARF RMF"' \
-                      ' srcreg="{reg}" exttype="POINT" tstep={ts}' \
-                      ' insts={i} psftype="2D_PSF"'
+    pnt_sp_cmd = 'cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" ' \
+                 'todo="SPEC ARF RMF" srcreg="{reg}" exttype="POINT" ' \
+                 'tstep={ts} insts={i} psftype="2D_PSF"'
 
     # You can't control the whole name of the output of srctool, so this renames it to the XGA format
     rename_cmd = 'mv srctoolout_{i_no}??_{type}* {nn}'
@@ -492,8 +516,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     #   that does not include the light leak affecting TMs 5 & 7.
     remove_merged_dr1_8 = 'rm *srctoolout_8*'
     remove_merged_dr1_9 = 'rm *srctoolout_9*'
-    # We also set up a command that will remove all spectra BUT the combined one, for when that is all the user wants
-    #  (though honestly it seems wasteful to generate them all and not use them, this might change later
+    # We also set up a command that will remove all spectra BUT the combined one
     remove_all_but_merged_cmd = "rm *srctoolout_*"
 
     # Grouping the spectra will be done using the HEASoft tool 'ftgrouppha' - we make sure to remove the original
@@ -511,76 +534,109 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     sources_paths = []
     sources_extras = []
     sources_types = []
+    # TODO HAVE TO ITERATE THROUGH EROSITA AND ERASS
     for s_ind, source in enumerate(sources):
         source: BaseSource
         cmds = []
         final_paths = []
         extra_info = []
 
-        # By this point we know that at least one of the sources has eROSITA data associated (we checked that at the
-        #  beginning of this function), we still need to append the empty cmds, paths, extrainfo, and ptypes to 
-        #  the final output, so that the cmd_list and input argument 'sources' have the same length, which avoids
-        #  bugs occuring in the esass_call wrapper
-        if 'erosita' not in source.telescopes:
-            sources_cmds.append(np.array(cmds))
-            sources_paths.append(np.array(final_paths))
-            # This contains any other information that will be needed to instantiate the class
-            # once the eSASS cmd has run
-            sources_extras.append(np.array(extra_info))
-            sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
+        for er_miss in ['erosita', 'erass']:
+            # By this point we know that at least one of the sources has eROSITA data
+            #  associated (we checked that at the beginning of this function).
+            #  However, for those sources that don't, we still need to append the empty
+            #  cmds, paths, extra_info, and ptypes to the final output, so that the
+            #  cmd_list and input argument 'sources' have the same length, which avoids
+            #  bugs occurring in the esass_call wrapper
+            if er_miss not in source.telescopes:
+                sources_cmds.append(np.array(cmds))
+                sources_paths.append(np.array(final_paths))
+                # This contains any other information that will be needed to instantiate the class
+                # once the eSASS cmd has run
+                sources_extras.append(np.array(extra_info))
+                sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
 
-            # then we can continue with the rest of the sources
-            continue
+                # Now we can continue with the rest of the sources
+                continue
 
-        # need to set this so the combine_obs variable doesnt get overwritten
-        use_combine_obs = combine_obs
-        # if the user has set combine_obs to True and there is only one observation, then we
-        # use the combine_obs = False functionality instead
-        if use_combine_obs and (len(source.obs_ids['erosita']) == 1):
-            use_combine_obs = False
+            # need to set this so the combine_obs variable doesn't get overwritten
+            use_combine_obs = combine_obs
+            # if the user has set combine_obs to True and there is only one observation, then we
+            # use the combine_obs = False functionality instead
+            if use_combine_obs and (len(source.obs_ids[er_miss]) == 1):
+                use_combine_obs = False
 
-        if outer_radius != 'region':
-            # Finding interloper regions within the radii we have specified has been put here because it all works in
-            #  degrees and as such only needs to be run once for all the different observations.
-            # TODO ASSUMPTION8 telescope agnostic version of the regions_within_radii will have telescope argument
-            interloper_regions = source.regions_within_radii(inner_radii[s_ind], outer_radii[s_ind], "erosita",
+            # For convenience, we extract the current source's src region radii
+            #  from the big array and put them in some variables
+            src_inn_rad = inner_radii[s_ind]
+            src_out_rad = outer_radii[s_ind]
+            # Can now use a source class method to find which 'interloper' (or contaminating) regions
+            #  are within the source region defined by the inner and outer radii.
+            # This only needs to be run once per source, because it all works in the
+            #  RA-Dec system rather than sky or detector pixel coordinates
+            interloper_regions = source.regions_within_radii(src_inn_rad,
+                                                             src_out_rad,
+                                                             er_miss,
                                                              source.default_coord)
-            # This finds any regions which
-            # TODO ASSUMPTION8 telescope agnostic version of the regions_within_radii will have telescope argument
-            back_inter_reg = source.regions_within_radii(outer_radii[s_ind] * source.background_radius_factors[0],
-                                                         outer_radii[s_ind] * source.background_radius_factors[1],
-                                                         "erosita", source.default_coord)
-            src_inn_rad_str = inner_radii[s_ind].value
-            src_out_rad_str = outer_radii[s_ind].value
+
+            # We repeat the exercise for the background region
+            bck_inn_rad = outer_radii[s_ind] * source.background_radius_factors[0]
+            bck_out_rad = outer_radii[s_ind] * source.background_radius_factors[1]
+            back_inter_reg = source.regions_within_radii(bck_inn_rad,
+                                                         bck_out_rad,
+                                                         er_miss,
+                                                         source.default_coord)
+
             # The key under which these spectra will be stored
-            spec_storage_name = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}"
-            spec_storage_name = spec_storage_name.format(ra=source.default_coord[0].value,
-                                                         dec=source.default_coord[1].value,
-                                                         ri=src_inn_rad_str, ro=src_out_rad_str, gr=group_spec)
-        else:
-            spec_storage_name = "region"
+            spec_stor_name = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}"
+            spec_stor_name = spec_stor_name.format(ra=source.default_coord[0].value,
+                                                   dec=source.default_coord[1].value,
+                                                   ri=src_inn_rad.value,
+                                                   ro=src_out_rad.value,
+                                                   gr=group_spec)
 
-        # Adds on the extra information about grouping to the storage key
-        spec_storage_name += extra_name
+            # Adds on the extra information about grouping to the storage key
+            spec_stor_name += extra_name
 
-        if not use_combine_obs:
-            # Check which event lists are associated with each individual source
-            for evt_list in source.get_products("events", telescope='erosita', just_obj=True):
-                # This function then uses the evtlist to generate spec commands, final paths, 
-                # and extra info, it will then append them to the cmds, final_paths, and extra_info lists
-                # that are defined above
-                _append_spec_info(evt_list)
+            # Now we start to cycle through event lists (or just the one list if there
+            #  is only one skytile/observation associated with the source).
+            if not use_combine_obs:
+                # Cycle through the event lists for each sky tile
+                for evt_list in source.get_products("events", telescope=er_miss):
+                    # Mainly for code-completion purposes in IDE
+                    evt_list: EventList
 
-        else:
-            # getting Eventlist product
-            evt_list = source.get_products("combined_events", just_obj=True, telescope="erosita")[0]
+                    # This internal function uses the evtlist to prepare spec
+                    #  commands, final paths, and extra info
+                    out_cmd, out_fin_paths, out_ex_info = _make_spec_cmd_info(evt_list)
 
-            # This function then uses the evtlist to generate spec commands, final paths, 
-            # and extra info, it will then append them to the cmds, final_paths, and extrainfo lists
-            # that are defined above
-            _append_spec_info(evt_list)
+                    # Add the output commands for the current event list to the overall
+                    #  set of commands we've set up
+                    cmds += out_cmd
+                    # Same deal for the final paths and extra information dicts
+                    final_paths += out_fin_paths
+                    extra_info += out_ex_info
+            else:
+                # In this case, the sky tiles are to be combined, so we grab the combined
+                #  event list
+                evt_list = source.get_products("combined_events", telescope=er_miss)[0]
+                # Mainly for code-completion purposes in IDE
+                evt_list: EventList
 
+                # This function then uses the evtlist to prepare spec commands, final
+                #  paths, and extra info
+                out_cmd, out_fin_paths, out_ex_info = _make_spec_cmd_info(evt_list)
 
+                # Add the output commands for the current event list to the overall set
+                #  of commands we've set up and do the same for output paths and
+                #  extra info
+                cmds += out_cmd
+                final_paths += out_fin_paths
+                extra_info += out_ex_info
+
+        # Turn the overall, final, set of commands, output paths, and extra information
+        #  into numpy arrays - this is because it is easier to index and mask them
+        #  than it is for lists
         sources_cmds.append(np.array(cmds))
         sources_paths.append(np.array(final_paths))
         # This contains any other information that will be needed to instantiate the class

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:49. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:01. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -501,6 +501,15 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     pnt_sp_cmd = 'cd {d}; srctool eventfiles="{ef}" srccoord="{sc}" ' \
                  'todo="SPEC ARF RMF" srcreg="{reg}" exttype="POINT" ' \
                  'tstep={ts} insts={i} psftype="2D_PSF"'
+
+    # The DR1 version of eSASS has an additional argument that can be passed to specify
+    #  which instruments should be written to output files - we want to be able to
+    #  set that to avoid some warnings that clog up the logs
+    print(ESASS_VERSION)
+    if ESASS_VERSION == "ESASS4DR1":
+        ext_sp_cmd += " writeinsts={i}"
+        back_sp_cmd += " writeinsts={i}"
+        pnt_sp_cmd += " writeinsts={i}"
 
     # You can't control the whole name of the output of srctool, so this renames it to the XGA format
     rename_cmd = 'mv srctoolout_{i_no}??_{type}* {nn}'

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:20. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:35. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -546,7 +546,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             #  cmd_list and input argument 'sources' have the same length, which avoids
             #  bugs occurring in the esass_call wrapper
             if er_miss not in source.telescopes:
-                print("WHAT?")
                 sources_cmds.append(np.array(cmds))
                 sources_paths.append(np.array(final_paths))
                 # This contains any other information that will be needed to instantiate the class
@@ -632,13 +631,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 final_paths += out_fin_paths
                 extra_info += out_ex_info
 
-        print(cmds)
-        print('\n\n')
-        print(final_paths)
-        print('\n\n')
-        print(extra_info)
-        print('\n\n')
-
         # Turn the overall, final, set of commands, output paths, and extra information
         #  into numpy arrays - this is because it is easier to index and mask them
         #  than it is for lists
@@ -648,6 +640,11 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
         #  once the eSASS cmd has run
         sources_extras.append(np.array(extra_info))
         sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
+
+        print(len(cmds), len(final_paths), len(extra_info))
+        print('\n')
+
+    print(len(sources_cmds), len(sources_paths), len(sources_extras), len(sources_types))
 
     return sources_cmds, stack, execute, num_cores, sources_types, sources_paths, sources_extras, disable_progress
 

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 28/07/2025, 11:02. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -64,12 +64,11 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
         instead of for one combined observation.
     :param bool force_gen: This boolean flag will force the regeneration of spectra, even if they already exist.
     """
-    def _append_spec_info(evt_list):
+
+    def _append_spec_info(cur_evt_list):
         """
         Internal method to get the parameters required for the srctool spectral generation command.
         """
-        # extracting the obs_id to use later
-        obs_id = evt_list.obs_id
 
         # Then we have to account for the two different modes this function can be used in - generating spectra
         #  for individual telescope models, or generating a single stacked spectrum for all telescope modules
@@ -90,12 +89,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             try:
                 if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
                     check_sp = source.get_combined_spectra(outer_radii[s_ind], inst, inner_radii[s_ind], group_spec,
-                                            min_counts, min_sn, telescope='erosita')
+                                                           min_counts, min_sn, telescope='erosita')
 
                 else:
                     # Got to check if this spectrum already exists
-                    check_sp = source.get_spectra(outer_radii[s_ind], obs_id, inst, inner_radii[s_ind], group_spec,
-                                            min_counts, min_sn, telescope='erosita')
+                    check_sp = source.get_spectra(outer_radii[s_ind], cur_evt_list.obs_id, inst, inner_radii[s_ind],
+                                                  group_spec,
+                                                  min_counts, min_sn, telescope='erosita')
                 exists = True
 
             except NoProductAvailableError:
@@ -104,20 +104,17 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             if exists and check_sp.usable and not force_gen:
                 continue
 
-            # Getting the source name
-            source_name = source.name
-
             # eROSITA observations have the potential to be in pointed or survey modes - we change the time step
             #  based on that. We suspect that the time step is almost irrelevant for pointed mode observations, as
             #  the pointing of the spacecraft won't be changing appreciably
-            if evt_list.header['OBS_MODE'] == 'POINTING':
+            if cur_evt_list.header['OBS_MODE'] == 'POINTING':
                 t_step = t_step_point
-            elif evt_list.header['OBS_MODE'] == 'SURVEY':
+            elif cur_evt_list.header['OBS_MODE'] == 'SURVEY':
                 t_step = t_step_survey
             else:
                 warn("XGA does not recognise the eROSITA OBS_MODE '{om}' - the timestep is defaulting to the "
-                    "survey mode value ({ts})".format(om=evt_list.header['OBS_MODE'], ts=t_step_survey),
-                    stacklevel=2)
+                     "survey mode value ({ts})".format(om=cur_evt_list.header['OBS_MODE'], ts=t_step_survey),
+                     stacklevel=2)
                 t_step = t_step_survey
 
             # setting up file names for output files
@@ -127,7 +124,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 rand_ident = randint(0, 100_000_000)
                 # Makes absolutely sure that the random integer hasn't already been used
                 while len([f for f in os.listdir(final_dest_dir)
-                        if str(rand_ident) in f.split(OUTPUT+"erosita/combined/")[-1]]) != 0:
+                           if str(rand_ident) in f.split(OUTPUT + "erosita/combined/")[-1]]) != 0:
                     rand_ident = randint(0, 100_000_000)
 
                 dest_dir = os.path.join(final_dest_dir, "temp_srctool_{}".format(rand_ident))
@@ -137,7 +134,8 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 # The temporary region files necessary to generate eROSITA spectra (if contaminating sources are
                 #  being removed) will be written to a different temporary folder using the same random identifier.
                 rand_ident = randint(0, 100_000_000)
-                dest_dir = OUTPUT + "erosita/" + "{o}/{i}_{n}_temp_{r}/".format(o=obs_id, i=inst, n=source_name,
+                dest_dir = OUTPUT + "erosita/" + "{o}/{i}_{n}_temp_{r}/".format(o=cur_evt_list.obs_id, i=inst,
+                                                                                n=source.name,
                                                                                 r=rand_ident)
             # If something got interrupted and the temp directory still exists, and it somehow has the same
             #  random number, this will remove it
@@ -150,36 +148,37 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             os.mkdir(dest_dir)
             # The temporary directory will now have a symlink to the relevant event list, with the symlink name
             #  the same as the actual event list
-            os.symlink(evt_list.path, os.path.join(dest_dir, os.path.basename(evt_list.path)))
+            os.symlink(cur_evt_list.path, os.path.join(dest_dir, os.path.basename(cur_evt_list.path)))
 
             # If there is no match to a region, the source region returned by this method will be None,
             #  and if the user wants to generate spectra from region files, we have to ignore that observations
-            # TODO ASSUMPTION6 source.source_back_regions will have a telescope parameter
-            if outer_radius == "region" and source.source_back_regions("erosita", "region", obs_id)[0] is None:
+            if outer_radius == "region" and source.source_back_regions("erosita", "region", cur_evt_list.obs_id)[
+                0] is None:
                 raise eROSITAImplentationError("XGA for eROSITA does not support the outer_radius='region' "
-                                            "argument.")
+                                               "argument.")
 
             # Because the region will be different for each ObsID, I have to call the setup function here
             if outer_radius == 'region':
                 raise eROSITAImplentationError("XGA for eROSITA does not support the outer_radius='region' "
-                                            "argument.")
+                                               "argument.")
 
             else:
                 # This constructs the eSASS strings/region files for any radius that isn't 'region'
-                reg = get_annular_esass_region(source, inner_radii[s_ind], outer_radii[s_ind], obs_id,
-                                            interloper_regions=interloper_regions,
-                                            central_coord=source.default_coord, rand_ident=rand_ident)
+                reg = get_annular_esass_region(source, inner_radii[s_ind], outer_radii[s_ind], cur_evt_list.obs_id,
+                                               interloper_regions=interloper_regions,
+                                               central_coord=source.default_coord, rand_ident=rand_ident)
                 b_reg = get_annular_esass_region(source, outer_radii[s_ind] * source.background_radius_factors[0],
-                                                outer_radii[s_ind] * source.background_radius_factors[1], obs_id,
-                                                interloper_regions=back_inter_reg,
-                                                central_coord=source.default_coord, bkg_reg=True,
-                                                rand_ident=rand_ident)
+                                                 outer_radii[s_ind] * source.background_radius_factors[1],
+                                                 cur_evt_list.obs_id,
+                                                 interloper_regions=back_inter_reg,
+                                                 central_coord=source.default_coord, bkg_reg=True,
+                                                 rand_ident=rand_ident)
                 inn_rad_degrees = inner_radii[s_ind]
                 out_rad_degrees = outer_radii[s_ind]
 
                 # TODO implement the detector map
                 # This creates a detection map for the source and background region
-                # map_path = _det_map_creation(outer_radii[s_ind], source, obs_id, inst)
+                # map_path = _det_map_creation(outer_radii[s_ind], source, cur_evt_list.obs_id, inst)
 
             # Setting up file names that include the extra variables
             if group_spec and min_counts is not None:
@@ -193,9 +192,9 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # TODO TIDY THIS UP, THE STORAGE NAMES OF THE SPECTRA ARE ALREADY DEFINED
             # The names of spectra will be different depending on if it is from a combined eventlist
             if use_combine_obs and (len(source.obs_ids['erosita']) > 1):
-                prefix = str(rand_ident) + '_{i}_'.format(i=inst) + '{n}_'.format(n=source_name)
+                prefix = str(rand_ident) + '_{i}_'.format(i=inst) + '{n}_'.format(n=source.name)
             else:
-                prefix = "{o}_{i}_{n}_".format(o=obs_id, i=inst, n=source_name)
+                prefix = "{o}_{i}_{n}_".format(o=cur_evt_list.obs_id, i=inst, n=source.name)
 
             spec_str = "ra{ra}_dec{dec}_ri{ri}_ro{ro}_grp{gr}{ex}_spec.fits"
             spec_str = prefix + spec_str
@@ -241,19 +240,21 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
             # These file names are for the debug images of the source and background images, they will not be loaded
             #  in as a XGA products, but exist purely to check by eye if necessary
-            dim = "{o}_{i}_{n}_ra{ra}_dec{dec}_ri{ri}_ro{ro}_debug.fits".format(o=obs_id, i=inst, n=source_name,
+            dim = "{o}_{i}_{n}_ra{ra}_dec{dec}_ri{ri}_ro{ro}_debug.fits".format(o=cur_evt_list.obs_id, i=inst,
+                                                                                n=source.name,
                                                                                 ra=source.default_coord[0].value,
                                                                                 dec=source.default_coord[1].value,
                                                                                 ri=src_inn_rad_str,
                                                                                 ro=src_out_rad_str)
             b_dim = ("{o}_{i}_{n}_ra{ra}_dec{dec}_ri{ri}_ro{ro}_"
-                     "back_debug.fits").format(o=obs_id, i=inst, n=source_name, ra=source.default_coord[0].value,
+                     "back_debug.fits").format(o=cur_evt_list.obs_id, i=inst, n=source.name,
+                                               ra=source.default_coord[0].value,
                                                dec=source.default_coord[1].value, ri=src_inn_rad_str,
                                                ro=src_out_rad_str)
 
             # TODO ADD MANY MORE COMMENTS
             coord_str = "icrs;{ra}, {dec}".format(ra=source.default_coord[0].value,
-                                                dec=source.default_coord[1].value)
+                                                  dec=source.default_coord[1].value)
             src_reg_str = reg  # dealt with in get_annular_esass_region
 
             # TODO allow user to chose tstep and xgrid
@@ -279,20 +280,22 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                                         telescope='erosita')
                     else:
                         # We only need the image path for extended source generation
-                        im = source.get_images(obs_id, lo_en=Quantity(0.2, 'keV'), hi_en=Quantity(10.0, 'keV'),
+                        im = source.get_images(cur_evt_list.obs_id, lo_en=Quantity(0.2, 'keV'),
+                                               hi_en=Quantity(10.0, 'keV'),
                                                telescope='erosita')
                     # We have a slightly different command for extended and point sources
-                    s_cmd_str = ext_srctool_cmd.format(d=dest_dir, ef=os.path.basename(evt_list.path), sc=coord_str,
+                    s_cmd_str = ext_srctool_cmd.format(d=dest_dir, ef=os.path.basename(cur_evt_list.path), sc=coord_str,
                                                        reg=src_reg_str, i=inst_no, ts=t_step, em=im.path, et=et)
                 except:
                     raise ValueError(f"it was this sources {source.name}")
 
             else:
-                s_cmd_str = pnt_srctool_cmd.format(d=dest_dir, ef=os.path.basename(evt_list.path), sc=coord_str,
+                s_cmd_str = pnt_srctool_cmd.format(d=dest_dir, ef=os.path.basename(cur_evt_list.path), sc=coord_str,
                                                    reg=src_reg_str, i=inst_no, ts=t_step)
 
             # TODO FIGURE OUT WHAT TO DO ABOUT THE TIMESTEP
-            sb_cmd_str = bckgr_srctool_cmd.format(ef=os.path.basename(evt_list.path), sc=coord_str, breg=bsrc_reg_str,
+            sb_cmd_str = bckgr_srctool_cmd.format(ef=os.path.basename(cur_evt_list.path), sc=coord_str,
+                                                  breg=bsrc_reg_str,
                                                   i=inst_no, ts=t_step * 4)
             # Filling out the grouping command
             grp_cmd_str = grp_cmd.format(infi=no_grp_spec, of=spec, gt=group_type, gs=group_scale)
@@ -335,7 +338,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # Removing the 'merged spectra' output of srctool, the background in this case
             if combine_tm:
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
-                                    remove_all_but_merged_cmd])
+                                     remove_all_but_merged_cmd])
             else:
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
                 # Add handling for DR1 produced merged files
@@ -346,7 +349,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                     else:
                         # Remove "TM8" output otherwise
                         cmd_str += f";{remove_merged_dr1_8}"
-
 
             # If the user wants to group the spectra then this command should be added
             if group_spec:
@@ -359,20 +361,20 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # Adds clean up commands to move all generated files and remove temporary directory
             cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
             # If temporary region files were made, they will be here
-            if os.path.exists(OUTPUT + 'erosita/' + obs_id + '/temp_regs_{i}'.format(i=rand_ident)):
+            if os.path.exists(OUTPUT + 'erosita/' + cur_evt_list.obs_id + '/temp_regs_{i}'.format(i=rand_ident)):
                 # Removing this directory
                 cmd_str += ";rm -r temp_regs_{i}".format(i=rand_ident)
 
             cmds.append(cmd_str)  # Adds the full command to the set
 
-            final_paths.append(os.path.join(OUTPUT, "erosita", obs_id, spec))
+            final_paths.append(os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, spec))
             extra_info.append({"inner_radius": inn_rad_degrees, "outer_radius": out_rad_degrees,
-                               "rmf_path": os.path.join(OUTPUT, "erosita", obs_id, rmf),
-                               "arf_path": os.path.join(OUTPUT, "erosita", obs_id, arf),
-                               "b_spec_path": os.path.join(OUTPUT, "erosita", obs_id, b_spec),
-                               "b_rmf_path": os.path.join(OUTPUT, "erosita", obs_id, b_rmf),
-                               "b_arf_path": os.path.join(OUTPUT, "erosita", obs_id, b_arf),
-                               "obs_id": obs_id, "instrument": inst,
+                               "rmf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, rmf),
+                               "arf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, arf),
+                               "b_spec_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_spec),
+                               "b_rmf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_rmf),
+                               "b_arf_path": os.path.join(OUTPUT, "erosita", cur_evt_list.obs_id, b_arf),
+                               "obs_id": cur_evt_list.obs_id, "instrument": inst,
                                "central_coord": source.default_coord,
                                "grouped": group_spec,
                                "min_counts": min_counts,
@@ -381,7 +383,14 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                "from_region": from_region,
                                "telescope": "erosita"})
 
-    # TODO MORE COMMENTS
+    # Early XGA could generate spectra within the detection regions of the source, but
+    #  that has been deprecated for quite a while, as it was a bad idea. The generation
+    #  of spectra within user-specified regions will be possible, but it will be
+    #  implemented differently. The original way was bad because the detection region
+    #  could/almost certainly would be different for each observation
+    if outer_radius == 'region':
+        raise ValueError("The string 'region' is no longer a valid option for "
+                         "the 'outer_radius' argument.")
 
     # TODO This will change in a future release, so that the user can control it - see issue #1113. The definitions
     #  are up the top of the function as a reminder
@@ -436,7 +445,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     else:
         extra_name = ''
 
-    # SASS' srctool operates quite differently for extended sources and point sources. We are going to want a
+    # eSASS' srctool operates quite differently for extended sources and point sources. We are going to want a
     #  detector map for extended sources to weight the ARF calculation, so here we check the source type
     if isinstance(sources[0], (ExtendedSource, GalaxyCluster)):
         ex_src = True
@@ -487,8 +496,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     #  (though honestly it seems wasteful to generate them all and not use them, this might change later
     remove_all_but_merged_cmd = "rm *srctoolout_*"
 
-    # TODO include the background file - YES
-    # TODO regroup the background file too 
     # Grouping the spectra will be done using the HEASoft tool 'ftgrouppha' - we make sure to remove the original
     #  ungrouped file. I think maybe that approach is safer than turning clobber on and just having the original
     #  generated file with a name that only truly applies once grouping has been done.
@@ -560,10 +567,9 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # Check which event lists are associated with each individual source
             for evt_list in source.get_products("events", telescope='erosita', just_obj=True):
                 # This function then uses the evtlist to generate spec commands, final paths, 
-                # and extra info, it will then append them to the cmds, final_paths, and extrainfo lists
+                # and extra info, it will then append them to the cmds, final_paths, and extra_info lists
                 # that are defined above
                 _append_spec_info(evt_list)
-
 
         else:
             # getting Eventlist product
@@ -684,7 +690,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 def srctool_spectrum(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, Quantity],
                      inner_radius: Union[str, Quantity] = Quantity(0, 'arcsec'), group_spec: bool = True,
                      min_counts: int = 5, min_sn: float = None, num_cores: int = NUM_CORES,
-                     disable_progress: bool = False, combine_tm: bool = True,  combine_obs: bool = True, force_gen: bool = False):
+                     disable_progress: bool = False, combine_tm: bool = True, combine_obs: bool = True, force_gen: bool = False):
 
     """
     A wrapper for all the eSASS and Heasoft processes necessary to generate an eROSITA spectrum that can be analysed

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:35. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:41. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -533,28 +533,30 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     sources_types = []
     # TODO HAVE TO ITERATE THROUGH EROSITA AND ERASS
     for s_ind, source in enumerate(sources):
+        # By this point we know that at least one of the sources has eROSITA data
+        #  associated (we checked that at the beginning of this function).
+        #  However, for those sources that don't, we still need to append the empty
+        #  cmds, paths, extra_info, and ptypes to the final output, so that the
+        #  cmd_list and input argument 'sources' have the same length, which avoids
+        #  bugs occurring in the esass_call wrapper
+        if 'erosita' not in source.telescopes and 'erass' not in source.telescopes:
+            sources_cmds.append(np.array(cmds))
+            sources_paths.append(np.array(final_paths))
+            # This contains any other information that will be needed to
+            #  instantiate the Spectrum class once the eSASS cmd has run
+            sources_extras.append(np.array(extra_info))
+            sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
+
+            # Now we can continue with the rest of the sources
+            continue
+
         source: BaseSource
         cmds = []
         final_paths = []
         extra_info = []
 
         for er_miss in ['erosita', 'erass']:
-            # By this point we know that at least one of the sources has eROSITA data
-            #  associated (we checked that at the beginning of this function).
-            #  However, for those sources that don't, we still need to append the empty
-            #  cmds, paths, extra_info, and ptypes to the final output, so that the
-            #  cmd_list and input argument 'sources' have the same length, which avoids
-            #  bugs occurring in the esass_call wrapper
-            if er_miss not in source.telescopes:
-                sources_cmds.append(np.array(cmds))
-                sources_paths.append(np.array(final_paths))
-                # This contains any other information that will be needed to instantiate the class
-                # once the eSASS cmd has run
-                sources_extras.append(np.array(extra_info))
-                sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
 
-                # Now we can continue with the rest of the sources
-                continue
 
             # need to set this so the combine_obs variable doesn't get overwritten
             use_combine_obs = combine_obs
@@ -640,11 +642,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
         #  once the eSASS cmd has run
         sources_extras.append(np.array(extra_info))
         sources_types.append(np.full(sources_cmds[-1].shape, fill_value="spectrum"))
-
-        print(len(cmds), len(final_paths), len(extra_info))
-        print('\n')
-
-    print(len(sources_cmds), len(sources_paths), len(sources_extras), len(sources_types))
 
     return sources_cmds, stack, execute, num_cores, sources_types, sources_paths, sources_extras, disable_progress
 

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:04. Copyright (c) The Contributors
+#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -341,14 +341,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_all_but_merged_cmd])
             else:
                 cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
-                # Add handling for DR1 produced merged files
-                # if ESASS_VERSION == "ESASS4DR1":
-                #     # Remove "TM9" output if the instrument number is 5 or 7
-                #     if inst_no in ['5', '7']:
-                #         cmd_str += f";{remove_merged_dr1_9}"
-                #     else:
-                #         # Remove "TM8" output otherwise
-                #         cmd_str += f";{remove_merged_dr1_8}"
 
             # This currently ensures that there is a ';' divider between these two chunks of commands - hopefully
             #  we'll neaten it up at some point
@@ -360,14 +352,6 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                      remove_all_but_merged_cmd])
             else:
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
-                # Add handling for DR1 produced merged files
-                # if ESASS_VERSION == "ESASS4DR1":
-                #     # Remove "TM9" output if the instrument number is 5 or 7
-                #     if inst_no in ['5', '7']:
-                #         cmd_str += f";{remove_merged_dr1_9}"
-                #     else:
-                #         # Remove "TM8" output otherwise
-                #         cmd_str += f";{remove_merged_dr1_8}"
 
             # If the user wants to group the spectrum, then this command should be added
             if group_spec:
@@ -467,7 +451,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     if all([o is not None for o in [min_counts, min_sn]]):
         raise eSASSInputInvalid("Only one grouping option can passed, you can't group both by"
                                 " minimum counts AND by minimum signal to noise.")
-    # Should also check that the user has passed any sort of grouping argument, if they say they want to group
+    # Should also check that the user has passed any sort of grouping argument if they say they want to group
     elif group_spec and all([o is None for o in [min_counts, min_sn]]):
         raise eSASSInputInvalid("If you set group_spec=True, you must supply a grouping option, either min_counts"
                                 " or min_sn.")
@@ -531,7 +515,9 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     remove_merged_dr1_8 = 'rm *srctoolout_8*'
     remove_merged_dr1_9 = 'rm *srctoolout_9*'
     # We also set up a command that will remove all spectra BUT the combined one
-    remove_all_but_merged_cmd = "rm *srctoolout_*"
+    # TODO SORT THIS SHIT OUT?!
+    # remove_all_but_merged_cmd = "rm *srctoolout_*"
+    remove_all_but_merged_cmd = ""
 
     # Grouping the spectra will be done using the HEASoft tool 'ftgrouppha' - we make sure to remove the original
     #  ungrouped file. I think maybe that approach is safer than turning clobber on and just having the original

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 16:49. Copyright (c) The Contributors
+#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:04. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -369,7 +369,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 #         # Remove "TM8" output otherwise
                 #         cmd_str += f";{remove_merged_dr1_8}"
 
-            # If the user wants to group the spectrum then this command should be added
+            # If the user wants to group the spectrum, then this command should be added
             if group_spec:
                 # This both performs the grouping and deletes the original non-grouped file. A similar effect
                 #  could be ensured by turning clobber on for ftgrouppha, but I think this way is safer. That way
@@ -379,13 +379,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
             # Adds symlink-removal commands - we don't want to be moving them along
             #  with every else in the temporary working directory
-            cmd_str += "; rm {esym}".format(esym=evt_symlink_name)
-            # Image symlink will only be present if the source is extended
-            if extended_src:
-                cmd_str += "; rm {esym}".format(esym=im_symlink_name)
+            # cmd_str += "; rm {esym}".format(esym=evt_symlink_name)
+            # # Image symlink will only be present if the source is extended
+            # if extended_src:
+            #     cmd_str += "; rm {esym}".format(esym=im_symlink_name)
 
             # Adds clean up commands to move all generated files and remove the temporary directory
-            cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
+            # cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
             # If temporary region files were made, they will be here
             if os.path.exists(final_dest_dir + '/temp_regs_{i}'.format(i=rand_ident)):
                 # Removing this directory

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:56. Copyright (c) The Contributors
+#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 21:11. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -103,6 +103,12 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # Extracting just the instrument number for later use in eSASS commands (or indeed a list of instrument
             #  numbers if the user has requested a combined spectrum).
             inst_no = inst_nums[inst_ind]
+            # Also pick out the current instrument srctool ID - this will be passed
+            #  to the writeinsts argument of srctool. It will be identical to 'inst_no'
+            #  for individual telescope module spectra, and will be zero (to write a
+            #  combined spectrum of all specified TMs) for combined telescope
+            #  module spectra.
+            cur_inst_srctool_id = inst_srctool_id[inst_ind]
 
             try:
                 if use_combine_obs and (len(source.obs_ids[cur_evt_list.telescope]) > 1):
@@ -280,6 +286,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                               sc=coord_str,
                                               reg=reg,
                                               i=inst_no,
+                                              wi=cur_inst_srctool_id,
                                               ts=t_step,
                                               em=os.path.basename(im.path),
                                               et=ext_type)
@@ -291,6 +298,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                               sc=coord_str,
                                               reg=reg,
                                               i=inst_no,
+                                              wi=cur_inst_srctool_id,
                                               ts=t_step)
 
             # TODO FIGURE OUT WHAT TO DO ABOUT THE TIMESTEP
@@ -298,6 +306,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                                             sc=coord_str,
                                             breg=b_reg,
                                             i=inst_no,
+                                            wi=cur_inst_srctool_id,
                                             ts=t_step * 4)
             # Filling out the grouping command
             grp_cmd_str = grp_cmd.format(infi=no_grp_spec,
@@ -337,14 +346,10 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # We make sure to remove the 'merged spectra' output of srctool - which is identical to the
             #  instrument one if we generate for one spectrum at a time. Though only if the user hasn't actually
             #  ASKED for the merged spectrum
-            print('TM combo', combine_tm)
-
             if combine_tm:
-                # cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_all_but_merged_cmd])
-                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf])
+                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_all_but_merged_cmd])
             else:
-                # cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
-                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf])
+                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
 
             # This currently ensures that there is a ';' divider between these two chunks of commands - hopefully
             #  we'll neaten it up at some point
@@ -352,13 +357,10 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
             # Removing the 'merged spectra' output of srctool, for the background spectra in this case
             if combine_tm:
-                # cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
-                #                      remove_all_but_merged_cmd])
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
-                                     ])
+                                     remove_all_but_merged_cmd])
             else:
-                # cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
-                cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf])
+                cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
 
             # If the user wants to group the spectrum, then this command should be added
             if group_spec:
@@ -370,13 +372,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
             # Adds symlink-removal commands - we don't want to be moving them along
             #  with every else in the temporary working directory
-            # cmd_str += "; rm {esym}".format(esym=evt_symlink_name)
-            # # Image symlink will only be present if the source is extended
-            # if extended_src:
-            #     cmd_str += "; rm {esym}".format(esym=im_symlink_name)
+            cmd_str += "; rm {esym}".format(esym=evt_symlink_name)
+            # Image symlink will only be present if the source is extended
+            if extended_src:
+                cmd_str += "; rm {esym}".format(esym=im_symlink_name)
 
             # Adds clean up commands to move all generated files and remove the temporary directory
-            # cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
+            cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)
             # If temporary region files were made, they will be here
             if os.path.exists(final_dest_dir + '/temp_regs_{i}'.format(i=rand_ident)):
                 # Removing this directory
@@ -506,9 +508,9 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     #  which instruments should be written to output files - we want to be able to
     #  set that to avoid some warnings that clog up the logs
     if ESASS_VERSION == "ESASS4DR1":
-        ext_sp_cmd += " writeinsts={i}"
-        back_sp_cmd += " writeinsts={i}"
-        pnt_sp_cmd += " writeinsts={i}"
+        ext_sp_cmd += " writeinsts={wi}"
+        back_sp_cmd += " writeinsts={wi}"
+        pnt_sp_cmd += " writeinsts={wi}"
 
     # TODO SORT THIS SHIT OUT?!
     # You can't control the whole names of srctool outputs, so this renames it to the XGA format

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:57. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:20. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -546,6 +546,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             #  cmd_list and input argument 'sources' have the same length, which avoids
             #  bugs occurring in the esass_call wrapper
             if er_miss not in source.telescopes:
+                print("WHAT?")
                 sources_cmds.append(np.array(cmds))
                 sources_paths.append(np.array(final_paths))
                 # This contains any other information that will be needed to instantiate the class
@@ -630,6 +631,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 cmds += out_cmd
                 final_paths += out_fin_paths
                 extra_info += out_ex_info
+
+        print(cmds)
+        print('\n\n')
+        print(final_paths)
+        print('\n\n')
+        print(extra_info)
+        print('\n\n')
 
         # Turn the overall, final, set of commands, output paths, and extra information
         #  into numpy arrays - this is because it is easier to index and mask them

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:47. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:52. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -829,8 +829,10 @@ def esass_spectrum_set(sources: Union[BaseSource, BaseSample], radii: Union[List
     #  object, then that property contains the telescopes associated with that source, and if it is a Sample object
     #  then 'telescopes' contains the list of unique telescopes that are associated with at least one member source.
     # Clearly if eROSITA isn't associated at all, then continuing with this function would be pointless
-    if ((not isinstance(sources, list) and 'erosita' not in sources.telescopes) or
-            (isinstance(sources, list) and 'erosita' not in sources[0].telescopes)):
+    if ((not isinstance(sources, list) and (
+            'erosita' not in sources.telescopes and 'erass' not in sources.telescopes)) or
+            (isinstance(sources, list) and (
+                    'erosita' not in sources[0].telescopes and 'erass' not in sources[0].telescopes))):
         raise TelescopeNotAssociatedError("There are no eROSITA data associated with the source/sample, as such "
                                           "eROSITA spectra cannot be generated.")
 
@@ -912,7 +914,7 @@ def esass_spectrum_set(sources: Union[BaseSource, BaseSample], radii: Union[List
         #  beginning of this function), we still need to append the empty cmds, paths, extrainfo, and ptypes to 
         #  the final output, so that the cmd_list and input argument 'sources' have the same length, which avoids
         #  bugs occuring in the esass_call wrapper
-        if 'erosita' not in source.telescopes:
+        if 'erosita' not in source.telescopes and 'erass' not in source.telescopes:
             all_cmds.append(np.array(src_cmds))
             all_paths.append(np.array(src_paths))
             # This contains any other information that will be needed to instantiate the class

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:01. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:07. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -156,7 +156,8 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             os.makedirs(dest_dir, exist_ok=True)
             # The temporary directory will now have a symlink to the relevant event list, with the symlink name
             #  the same as the actual event list
-            os.symlink(cur_evt_list.path, os.path.join(dest_dir, os.path.basename(cur_evt_list.path)))
+            evt_symlink_name = os.path.basename(cur_evt_list.path)
+            os.symlink(cur_evt_list.path, os.path.join(dest_dir, evt_symlink_name))
 
             # This constructs the eSASS strings/region files
             reg = get_annular_esass_region(source,
@@ -270,7 +271,8 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 # As with the paths to the event lists, it is possible that the image
                 #  file names will be too long for eSASS' srctool to handle. To
                 #  mitigate the potential problem, we make another symlink
-                os.symlink(im.path, os.path.join(dest_dir, os.path.basename(im.path)))
+                im_symlink_name = os.path.basename(im.path)
+                os.symlink(im.path, os.path.join(dest_dir, im_symlink_name))
 
                 # Fill out the spectrum generation (srctool) command specific to extended sources
                 s_cmd_str = ext_sp_cmd.format(d=dest_dir,
@@ -340,13 +342,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             else:
                 cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
                 # Add handling for DR1 produced merged files
-                if ESASS_VERSION == "ESASS4DR1":
-                    # Remove "TM9" output if the instrument number is 5 or 7
-                    if inst_no in ['5', '7']:
-                        cmd_str += f";{remove_merged_dr1_9}"
-                    else:
-                        # Remove "TM8" output otherwise
-                        cmd_str += f";{remove_merged_dr1_8}"
+                # if ESASS_VERSION == "ESASS4DR1":
+                #     # Remove "TM9" output if the instrument number is 5 or 7
+                #     if inst_no in ['5', '7']:
+                #         cmd_str += f";{remove_merged_dr1_9}"
+                #     else:
+                #         # Remove "TM8" output otherwise
+                #         cmd_str += f";{remove_merged_dr1_8}"
 
             # This currently ensures that there is a ';' divider between these two chunks of commands - hopefully
             #  we'll neaten it up at some point
@@ -359,13 +361,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             else:
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
                 # Add handling for DR1 produced merged files
-                if ESASS_VERSION == "ESASS4DR1":
-                    # Remove "TM9" output if the instrument number is 5 or 7
-                    if inst_no in ['5', '7']:
-                        cmd_str += f";{remove_merged_dr1_9}"
-                    else:
-                        # Remove "TM8" output otherwise
-                        cmd_str += f";{remove_merged_dr1_8}"
+                # if ESASS_VERSION == "ESASS4DR1":
+                #     # Remove "TM9" output if the instrument number is 5 or 7
+                #     if inst_no in ['5', '7']:
+                #         cmd_str += f";{remove_merged_dr1_9}"
+                #     else:
+                #         # Remove "TM8" output otherwise
+                #         cmd_str += f";{remove_merged_dr1_8}"
 
             # If the user wants to group the spectrum then this command should be added
             if group_spec:
@@ -374,6 +376,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
                 #  if grouping fails, there definitely won't be a file with the name of the grouped spectrum, but
                 #  no grouping applied.
                 cmd_str += "; " + grp_cmd_str
+
+            # Adds symlink-removal commands - we don't want to be moving them along
+            #  with every else in the temporary working directory
+            cmd_str += "; rm {esym}".format(esym=evt_symlink_name)
+            # Image symlink will only be present if the source is extended
+            if extended_src:
+                cmd_str += "; rm {esym}".format(esym=im_symlink_name)
 
             # Adds clean up commands to move all generated files and remove the temporary directory
             cmd_str += "; mv * ../; cd ..; rm -r {d}".format(d=dest_dir)

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:36. Copyright (c) The Contributors
+#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 10:56. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -337,10 +337,14 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
             # We make sure to remove the 'merged spectra' output of srctool - which is identical to the
             #  instrument one if we generate for one spectrum at a time. Though only if the user hasn't actually
             #  ASKED for the merged spectrum
+            print('TM combo', combine_tm)
+
             if combine_tm:
-                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_all_but_merged_cmd])
+                # cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_all_but_merged_cmd])
+                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf])
             else:
-                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
+                # cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf, remove_merged_cmd])
+                cmd_str = ";".join([s_cmd_str, rename_spec, rename_rmf, rename_arf])
 
             # This currently ensures that there is a ';' divider between these two chunks of commands - hopefully
             #  we'll neaten it up at some point
@@ -348,10 +352,13 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
             # Removing the 'merged spectra' output of srctool, for the background spectra in this case
             if combine_tm:
+                # cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
+                #                      remove_all_but_merged_cmd])
                 cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf,
-                                     remove_all_but_merged_cmd])
+                                     ])
             else:
-                cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
+                # cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf, remove_merged_cmd])
+                cmd_str += ";".join([sb_cmd_str, rename_b_spec, rename_b_rmf, rename_b_arf])
 
             # If the user wants to group the spectrum, then this command should be added
             if group_spec:
@@ -503,6 +510,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
         back_sp_cmd += " writeinsts={i}"
         pnt_sp_cmd += " writeinsts={i}"
 
+    # TODO SORT THIS SHIT OUT?!
     # You can't control the whole names of srctool outputs, so this renames it to the XGA format
     rename_cmd = 'mv srctoolout_{i_no}??_{type}* {nn}'
     # Having a string to remove the 'merged' spectra that srctool outputs, even when you only request one instrument
@@ -515,9 +523,7 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     remove_merged_dr1_8 = 'rm *srctoolout_8*'
     remove_merged_dr1_9 = 'rm *srctoolout_9*'
     # We also set up a command that will remove all spectra BUT the combined one
-    # TODO SORT THIS SHIT OUT?!
-    # remove_all_but_merged_cmd = "rm *srctoolout_*"
-    remove_all_but_merged_cmd = ""
+    remove_all_but_merged_cmd = "rm *srctoolout_*"
 
     # Grouping the spectra will be done using the HEASoft tool 'ftgrouppha' - we make sure to remove the original
     #  ungrouped file. I think maybe that approach is safer than turning clobber on and just having the original

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:41. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 14:49. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -556,7 +556,10 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
         extra_info = []
 
         for er_miss in ['erosita', 'erass']:
-
+            # Skip this iteration if the current skew of eROSITA isn't associated
+            #  with the current source
+            if er_miss not in source.telescopes:
+                continue
 
             # need to set this so the combine_obs variable doesn't get overwritten
             use_combine_obs = combine_obs

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:52. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:57. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -75,13 +75,12 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
 
         :param EventList cur_evt_list: The event list to generate spectra from.
         :return: A list of spectral generation commands, a list of final spectrum file
-            paths, and a list of dictionaries of extra information.
+            paths, and a list of extra information dictionaries.
         :rtype: Tuple[List[str], List[str], List[str]]
         """
 
         # Then we have to account for the two different modes this function can be used in - generating spectra
         #  for individual telescope models, or generating a single stacked spectrum for all telescope modules
-        # TODO NEED TO MAKE SURE THE RIGHT TMs ARE BEING USED HERE
         if combine_tm:
             inst_names = ['combined']
             inst_nums = ['"' + ' '.join([tm[-1] for tm in list(source.num_inst_obs[cur_evt_list.telescope].keys())]) + '"']
@@ -477,10 +476,8 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     if isinstance(sources[0], (ExtendedSource, GalaxyCluster)):
         # Set up a boolean value to tell us later on if this is an extended source
         extended_src = True
-
         # Sets the extent model type to MAP, which means we'll be using an image to encode the emission extent
         ext_type = 'MAP'
-
         # Ensures that the images we intend to use as extent maps have actually been generated
         evtool_image(sources, EROSITA_EXTMAP_LO_EN, EROSITA_EXTMAP_HI_EN, combine_obs=combine_obs, num_cores=NUM_CORES)
     else:

--- a/xga/generate/esass/spec.py
+++ b/xga/generate/esass/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:07. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 16:49. Copyright (c) The Contributors
 
 import os
 from copy import deepcopy, copy
@@ -514,13 +514,12 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     # The DR1 version of eSASS has an additional argument that can be passed to specify
     #  which instruments should be written to output files - we want to be able to
     #  set that to avoid some warnings that clog up the logs
-    print(ESASS_VERSION)
     if ESASS_VERSION == "ESASS4DR1":
         ext_sp_cmd += " writeinsts={i}"
         back_sp_cmd += " writeinsts={i}"
         pnt_sp_cmd += " writeinsts={i}"
 
-    # You can't control the whole name of the output of srctool, so this renames it to the XGA format
+    # You can't control the whole names of srctool outputs, so this renames it to the XGA format
     rename_cmd = 'mv srctoolout_{i_no}??_{type}* {nn}'
     # Having a string to remove the 'merged' spectra that srctool outputs, even when you only request one instrument
     remove_merged_cmd = 'rm *srctoolout_0*'

--- a/xga/generate/sas/lightcurve.py
+++ b/xga/generate/sas/lightcurve.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 24/07/2024, 16:16. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from random import randint
@@ -49,6 +49,16 @@ def _lc_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, Qu
         90% of available.
     :param bool disable_progress: Setting this to true will turn off the SAS generation progress bar.
     """
+
+    # Early XGA could generate spectra within the detection regions of the source, but
+    #  that has been deprecated for quite a while, as it was a bad idea. The generation
+    #  of spectra within user-specified regions will be possible, but it will be
+    #  implemented differently. The original way was bad because the detection region
+    #  could/almost certainly would be different for each observation
+    if outer_radius == 'region':
+        raise ValueError("The string 'region' is no longer a valid option for "
+                         "the 'outer_radius' argument.")
+
     # We check to see whether there is an XMM entry in the 'telescopes' property. If sources is a Source object, then
     #  that property contains the telescopes associated with that source, and if it is a Sample object then
     #  'telescopes' contains the list of unique telescopes that are associated with at least one member source.

--- a/xga/generate/sas/spec.py
+++ b/xga/generate/sas/spec.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 14/07/2025, 09:53. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 10:36. Copyright (c) The Contributors
 
 import os
 from copy import copy
@@ -50,6 +50,16 @@ def _spec_cmds(sources: Union[BaseSource, BaseSample], outer_radius: Union[str, 
     :param bool disable_progress: Setting this to true will turn off the SAS generation progress bar.
     :param bool force_gen: This boolean flag will force the regeneration of spectra, even if they already exist.
     """
+
+    # Early XGA could generate spectra within the detection regions of the source, but
+    #  that has been deprecated for quite a while, as it was a bad idea. The generation
+    #  of spectra within user-specified regions will be possible, but it will be
+    #  implemented differently. The original way was bad because the detection region
+    #  could/almost certainly would be different for each observation
+    if outer_radius == 'region':
+        raise ValueError("The string 'region' is no longer a valid option for "
+                         "the 'outer_radius' argument.")
+
     # We check to see whether there is an XMM entry in the 'telescopes' property. If sources is a Source object, then
     #  that property contains the telescopes associated with that source, and if it is a Sample object then
     #  'telescopes' contains the list of unique telescopes that are associated with at least one member source.

--- a/xga/sources/base.py
+++ b/xga/sources/base.py
@@ -1,10 +1,9 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 08/08/2025, 10:47. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:57. Copyright (c) The Contributors
 
 import gc
 import os
 import pickle
-import pprint
 from copy import deepcopy
 from shutil import move, copyfile
 from typing import Tuple, List, Dict, Union
@@ -24,7 +23,7 @@ from regions import (SkyRegion, EllipseSkyRegion, CircleSkyRegion, EllipsePixelR
 from .. import xga_conf, BLACKLIST
 from ..exceptions import (NotAssociatedError, NoValidObservationsError, NoProductAvailableError,
                           ModelNotAssociatedError, ParameterNotAssociatedError, NotSampleMemberError,
-                          TelescopeNotAssociatedError, PeakConvergenceFailedError, PeakConvergenceFailedError,
+                          TelescopeNotAssociatedError, PeakConvergenceFailedError,
                           XGADeveloperError)
 from ..imagetools.misc import pix_deg_scale
 from ..imagetools.misc import sky_deg_scale
@@ -727,36 +726,6 @@ class BaseSource:
         """
         return {tel: {i: len([i for o in self.instruments[tel] if i in self.instruments[tel][o]])
                       for i in ALLOWED_INST[tel]} for tel in self.instruments}
-
-    # @property
-    # def num_pn_obs(self) -> int:
-    #     """
-    #     Getter method that gives the number of PN observations.
-    #
-    #     :return: Integer number of PN observations associated with this source
-    #     :rtype: int
-    #     """
-    #     return len([o for o in self.obs_ids if 'pn' in self._products[o]])
-    #
-    # @property
-    # def num_mos1_obs(self) -> int:
-    #     """
-    #     Getter method that gives the number of MOS1 observations.
-    #
-    #     :return: Integer number of MOS1 observations associated with this source
-    #     :rtype: int
-    #     """
-    #     return len([o for o in self.obs_ids if 'mos1' in self._products[o]])
-    #
-    # @property
-    # def num_mos2_obs(self) -> int:
-    #     """
-    #     Getter method that gives the number of MOS2 observations.
-    #
-    #     :return: Integer number of MOS2 observations associated with this source
-    #     :rtype: int
-    #     """
-    #     return len([o for o in self.obs_ids if 'mos2' in self._products[o]])
 
     @property
     def disassociated(self) -> bool:

--- a/xga/utils.py
+++ b/xga/utils.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 25/08/2025, 15:50. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 15:20. Copyright (c) The Contributors
 
 import json
 import os
@@ -16,11 +16,10 @@ import pandas as pd
 import pkg_resources
 from astropy.constants import m_p, m_e
 from astropy.cosmology import LambdaCDM
+from astropy.io import fits
 from astropy.units import Quantity, def_unit, add_enabled_units
 from astropy.wcs import WCS
-from astropy.io import fits
 from fitsio import FITSHDR
-from fitsio import read_header
 from tqdm import tqdm
 
 from .exceptions import XGAConfigError, InvalidTelescopeError, NoTelescopeDataError
@@ -853,15 +852,25 @@ SASWARNING_LIST = warnings["WarnName"].values
 
 # --- eROSITA ---
 ESASS_VERSION = None
-eSASS_AVAIL = False
+ESASS_AVAIL = False
 if ('erosita' in USABLE and USABLE['erosita']) or ('erass' in USABLE and USABLE['erass']):
-    # TODO will have to handle the whole eSASS4DR1 and the original eSASS release thing at some point... sigh
+    # Run the 'which' command for evtool, one of the eSASS tasks
+    which_evtool = shutil.which("evtool")
+
     # This checks for an installation of eSASS
-    if shutil.which("evtool") is None:
+    if which_evtool is None:
         warn("No eSASS installation detected on system, as such all functions in xga.generate.esass will not work.",
              stacklevel=2)
     else:
-        eSASS_AVAIL = True
+        ESASS_AVAIL = True
+        if 'ESASS4EDR' in which_evtool.upper():
+            ESASS_VERSION = 'ESASS4EDR'
+        elif 'ESASS4DR1' in which_evtool.upper():
+            ESASS_VERSION = 'ESASS4DR1'
+        else:
+            warn(
+                "Unknown eSASS installation detected on system, as such some functions in xga.generate.esass may not work.",
+                stacklevel=2)
 # ---------------
 
 # --- Chandra ---

--- a/xga/xspec/fakeit.py
+++ b/xga/xspec/fakeit.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 17/11/2025, 14:25. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 13:57. Copyright (c) The Contributors
 
 import os
 from random import randint
@@ -158,20 +158,10 @@ def cluster_cr_conv(sources: Union[GalaxyCluster, ClusterSample], outer_radius: 
                 raise NoProductAvailableError("There are no matching spectra for {s} object, you "
                                                 "need to generate them first!".format(s=source.name))
 
-            # DAVID_QUESTION not sure what the purpose of this check is
-            #total_obs_inst = source.num_pn_obs + source.num_mos1_obs + source.num_mos2_obs
-
             # This is because many other parts of this function assume that spec_objs is iterable, and in the case of
             #  a source with only a single valid instrument for a single valid observation this may not be the case
             if isinstance(spec_objs, Spectrum):
                 spec_objs = [spec_objs]
-
-            # DAVID_QUESTION not sure what the purpose of this check is
-            #elif len(spec_objs) != total_obs_inst:
-            #    raise NoProductAvailableError("The number of matching spectra ({0}) is not equal to the number of "
-            #                                "instrument/observation combinations ({1}) for {2}.".format(len(spec_objs),
-            #                                                                                            total_obs_inst,
-            #                                                                                            source.name))
 
             # Turn RMF and ARF paths into TCL style list for substitution into template
             rmf_paths = "{" + " ".join([spec.rmf for spec in spec_objs]) + "}"

--- a/xga/xspec/run.py
+++ b/xga/xspec/run.py
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 17:17. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 17:27. Copyright (c) The Contributors
 
 import os
 from functools import wraps
@@ -69,6 +69,7 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
         warn("An XSPEC fit for {} has timed out".format(source_name), stacklevel=2)
         usable = False
 
+    # Have to decode the output and errors as they are in byte form
     out = out.decode("UTF-8").split("\n")
     err = err.decode("UTF-8").split("\n")
 

--- a/xga/xspec/run.py
+++ b/xga/xspec/run.py
@@ -1,8 +1,7 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 07/08/2025, 16:40. Copyright (c) The Contributors
+#  Last modified by David J Turner (turne540@msu.edu) 09/12/2025, 17:17. Copyright (c) The Contributors
 
 import os
-import warnings
 from functools import wraps
 # from multiprocessing.dummy import Pool
 from multiprocessing import Pool
@@ -18,10 +17,12 @@ from fitsio import FITS
 from tqdm import tqdm
 
 from .. import XSPEC_VERSION
-from ..exceptions import XSPECFitError, MultipleMatchError, NoMatchFoundError, XSPECNotFoundError, XGADeveloperError
+from ..exceptions import MultipleMatchError, NoMatchFoundError, XSPECNotFoundError, XGADeveloperError
 from ..samples.base import BaseSample
 from ..sources import BaseSource
 
+XGA_XSPEC_ERRS = ["No acceptable spectra are left after the minimum channel step",
+                  "No acceptable spectra are left after the cleaning step"]
 
 def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: float) \
         -> Tuple[Union[FITS, str], str, bool, list, list, str]:
@@ -45,7 +46,7 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
     usable = True
 
     # We're going to make a temporary pfiles directory which is a) local to the XGA directory, and thus sure to
-    #  be on the same filesystem (can be a performance issue for HPCs I think), and b) is unique to a particular
+    #  be on the same filesystem (can be a performance issue for HPCs I think); and b) is unique to a particular
     #  fit process, so there shouldn't be any clashes. The temporary file name is randomly generated
     tmp_ident = str(randint(0, int(100_000_000)))
     tmp_hea_dir = os.path.join(os.path.dirname(out_file), tmp_ident, 'pfiles/')
@@ -65,7 +66,7 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
         out, err = xspec_proc.communicate()
         # Need to infer the name of the source to supply it in the warning
         source_name = x_script.split('/')[-1].split("_")[0]
-        warnings.warn("An XSPEC fit for {} has timed out".format(source_name), stacklevel=2)
+        warn("An XSPEC fit for {} has timed out".format(source_name), stacklevel=2)
         usable = False
 
     out = out.decode("UTF-8").split("\n")
@@ -77,8 +78,8 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
     # We ignore that particular string in the errors identified from stdout because if we don't just it being
     #  present in the if statement in the executed script is enough to make XGA think that the fit failed, even if
     #  that error message was never printed at all
-    err_out_lines = [line.split("***Error: ")[-1] for line in out if "***Error" in line
-                     if "No acceptable spectra are left after the cleaning step" not in line]
+    err_out_lines = [line.split("***Error: ")[-1] for line in out
+                     if "***Error" in line and all([xxe not in line for xxe in XGA_XSPEC_ERRS])]
     err_out_line_init = [line for line in out if "You do not have an up-to-date version of Xspec.init" in line]
     warn_out_lines = [line.split("***Warning: ")[-1] for line in out if "***Warning" in line]
     err_err_lines = [line.split("***Error: ")[-1] for line in err if "***Error" in line]
@@ -89,8 +90,8 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
     else:
         usable = False
 
-    error = err_out_lines + err_err_lines + err_out_line_init
-    warn = warn_out_lines + warn_err_lines
+    cur_error = err_out_lines + err_err_lines + err_out_line_init
+    cur_warn = warn_out_lines + warn_err_lines
 
     if os.path.exists(out_file + "_info.csv") and run_type == "fit" and usable:
         # The original version of the xga_output.tcl script output everything as one nice neat fits file
@@ -132,20 +133,22 @@ def execute_cmd(x_script: str, out_file: str, src: str, run_type: str, timeout: 
     elif not os.path.exists(out_file):
         usable = False
         res_tables = None
-        error.append('Results table not written.')
+        cur_error.append('Results table not written.')
     else:
         res_tables = None
         usable = False
 
-    # This uses outfile name (which has a structure set by XGA, so this is reliable) to figure out which telescope
-    #  this script was run for - this isn't necessarily how I would have designed it from the beginning, but is a
-    #  good solution to get the telescope which doesn't require adding stuff to all the user-facing XSPEC functions
+    # This uses outfile name (has structure set by XGA, so this is reliable) to
+    #  figure out which telescope this script was run for. This isn't necessarily
+    #  how I would have designed it from the beginning, but is a good solution to get
+    #  the telescope which doesn't require adding stuff to all the user-facing
+    #  XSPEC functions
     if run_type ==  "conv_factors":
         tel = out_file.split('_')[-3]
     else:
         tel = out_file.split('_')[-1].split('.')[0]
 
-    return res_tables, src, usable, error, warn, tel
+    return res_tables, src, usable, cur_error, cur_warn, tel
 
 
 def xspec_call(xspec_func):
@@ -153,7 +156,6 @@ def xspec_call(xspec_func):
     This is used as a decorator for functions that produce XSPEC scripts. Depending on the
     system that XGA is running on (and whether the user requests parallel execution), the method of
     executing the XSPEC commands will change. This supports multi-threading.
-    :return:
     """
 
     @wraps(xspec_func)
@@ -200,14 +202,14 @@ def xspec_call(xspec_func):
             with tqdm(total=len(script_list), desc=desc) as fit, Pool(cores) as pool:
                 def callback(results_in):
                     """
-                    Callback function for the apply_async pool method, gets called when a task finishes
-                    and something is returned.
+                    Callback function for the apply_async pool method which gets
+                    called when a task finishes and something is returned.
                     """
                     nonlocal fit  # The progress bar will need updating
                     nonlocal results  # The dictionary the command call results are added to
 
-                    res_fits, rel_src, successful, err_list, warn_list, tel = results_in
-                    results[rel_src].append([res_fits, successful, err_list, warn_list, tel])
+                    res_fits, rel_src, successful, cur_err_list, cur_warn_list, cur_tel = results_in
+                    results[rel_src].append([res_fits, successful, cur_err_list, cur_warn_list, cur_tel])
                     fit.update(1)
 
                 for s_ind, s in enumerate(script_list):
@@ -238,7 +240,6 @@ def xspec_call(xspec_func):
             for res_set in results[src_repr]:
                 # res_set[0] = res_table, if it is None then the xspec fit has failed
                 if res_set[0] is None:
-                    print(res_set)
                     for err in res_set[2]:
                         errors_all_sources.append(err + " - {s}".format(s=s.name))
                 # Extract the telescope from the information passed back by the running of the fit

--- a/xga/xspec_scripts/general_xspec_fit.xcm
+++ b/xga/xspec_scripts/general_xspec_fit.xcm
@@ -164,7 +164,7 @@ foreach sp $spec_paths {{
 #############################################
 # Throw an error if no spectra passed
 #############################################
-# The fit script has to exit here if no spectra made it past our cleaning
+# The fit script exits here if none of the input spectra meet the minimum channel requirement
     if {{[llength $accept_min_chan_spec_paths] == 0}} {{
         puts stderr "***Error: No acceptable spectra are left after the minimum channel step"
         exit

--- a/xga/xspec_scripts/general_xspec_fit.xcm
+++ b/xga/xspec_scripts/general_xspec_fit.xcm
@@ -102,9 +102,87 @@ set nh_par_to_zero {nhmtz}
 #################################################
 
 
-# Here we run a pre-check to see which of the spectra are good enough to actually contribute anything to the fit
 #################################################
-# Running the spectral gauntlet
+# TCL constants
+#################################################
+set min_chan_req 10
+#################################################
+
+
+#################################################
+# Excluding spectra with insufficient noticed channels
+#################################################
+#############################################
+# Load spectra and ignore channels
+#############################################
+# For loop here to load in all the spectra, iterating over path list
+set counter 1
+foreach pa $spec_paths {{
+    # Loads each spectrum into its own data and plot group
+    data $counter:$counter $pa
+    incr counter
+    }}
+
+# Now we ignore the energy range that we don't want to use, for all loaded spectra
+ignore **:**-$ignore_lo_en **:$ignore_hi_en-**
+
+# If any channels have been labelled bad, this will discount them from analysis
+ignore bad
+#############################################
+
+#############################################
+# Throw an error if no spectra passed
+#############################################
+# This list will contain the paths to spectra which HAVE the minimum number of
+#  channels we require
+set accept_min_chan_spec_paths {{}}
+
+set sp_id 1
+foreach sp $spec_paths {{
+    set range [split [tcloutr noticed $sp_id] -]
+    set num_chan [expr [lindex $range 1] - [lindex $range 0]]
+
+    if {{$num_chan > $min_chan_req}} {{
+            lappend accept_min_chan_spec_paths $sp
+        }}
+
+    incr sp_id
+}}
+#############################################
+
+#############################################
+# Throw an error if no spectra passed
+#############################################
+# The fit script has to exit here if no spectra made it past our cleaning
+    if {{[llength $accept_min_chan_spec_paths] == 0}} {{
+        puts stderr "***Error: No acceptable spectra are left after the minimum channel step"
+        exit
+    }}
+#############################################
+
+#############################################
+# Cleaning up after minimum channel check
+#############################################
+# Need to replace the spec_paths variable with our new list of spectra that
+#  meet our minimum channel requirements (which will hopefully be all of the spectra!)
+set spec_paths $accept_min_chan_spec_paths
+# We remove all the spectra that we already loaded into XSPEC
+data none
+
+# And unset some TCL variables to restore our environment
+unset accept_min_chan_spec_paths
+unset num_chan
+unset range
+unset sp_id
+
+#############################################
+#################################################
+
+
+# Here we optionally run a pre-check to attempt to identify the spectra that can contribute some constraining
+#  power to the final simultaneous model fit.
+#################################################
+# Optional model fit quality check to exclude bad spectra [running the spectral gauntlet]
 #################################################
 if {{$run_pre_check == True}} {{
 
@@ -225,15 +303,11 @@ if {{$run_pre_check == True}} {{
     # This assembles a list of spec paths where each spec name is repeated N times (where N is the number of
     #  parameters in a model - tbabs*apec has 5 for instance), then we move onto the next spec_path
     set par_spec {{}}
-    set par_spec_chan {{}}
 
     set sp_id 1
     foreach sp $spec_paths {{
-        set range [split [tcloutr noticed $sp_id] -]
-        set num_chan [expr [lindex $range 1] - [lindex $range 0]]
         for {{set i 1}} {{$i <= $num_uniq_par}} {{incr i 1}} {{
             lappend par_spec $sp
-            lappend par_spec_chan $num_chan
         }}
         incr sp_id
     }}
@@ -266,11 +340,9 @@ if {{$run_pre_check == True}} {{
 
             # Read out the equivalent spectrum path for this particular parameter
             set cur_sp [lindex $par_spec [expr $ipar-1]]
-            # And the number of noticed channels for this spectrum
-            set cur_chan [lindex $par_spec_chan [expr $ipar-1]]
 
             # If the parameter meets our quality cuts then the spectrum is added to the good_spec_paths list
-            if {{$par_val > $check_lo_lim($pname) && $par_val < $check_hi_lim($pname) && $lo_err < $check_err_lim($pname) && $hi_err < $check_err_lim($pname) && $cur_chan > 10}} {{
+            if {{$par_val > $check_lo_lim($pname) && $par_val < $check_hi_lim($pname) && $lo_err < $check_err_lim($pname) && $hi_err < $check_err_lim($pname)}} {{
                 lappend good_spec_paths $cur_sp
             }}
         }}

--- a/xga/xspec_scripts/general_xspec_fit.xcm
+++ b/xga/xspec_scripts/general_xspec_fit.xcm
@@ -131,7 +131,7 @@ ignore bad
 #############################################
 
 #############################################
-# Throw an error if no spectra passed
+# Read the number of noticed channels and check if they meet our minimum requirement
 #############################################
 # This list will contain the paths to spectra which HAVE the minimum number of
 #  channels we require
@@ -139,9 +139,12 @@ set accept_min_chan_spec_paths {{}}
 
 set sp_id 1
 foreach sp $spec_paths {{
+    # Sets a variable containing the lower and upper limits of the noticed channels
     set range [split [tcloutr noticed $sp_id] -]
+    # Calculates the number of channels in the range
     set num_chan [expr [lindex $range 1] - [lindex $range 0]]
-
+    # Performs a check to see if the number of channels is greater than the minimum requirement, and
+    #  if it is, add the spectrum's path to the accepted list
     if {{$num_chan > $min_chan_req}} {{
             lappend accept_min_chan_spec_paths $sp
         }}
@@ -174,7 +177,6 @@ unset accept_min_chan_spec_paths
 unset num_chan
 unset range
 unset sp_id
-
 #############################################
 #################################################
 

--- a/xga/xspec_scripts/general_xspec_fit.xcm
+++ b/xga/xspec_scripts/general_xspec_fit.xcm
@@ -141,6 +141,14 @@ set sp_id 1
 foreach sp $spec_paths {{
     # Sets a variable containing the lower and upper limits of the noticed channels
     set range [split [tcloutr noticed $sp_id] -]
+
+    # If there are no noticed channels, then it is possible for the just-set 'range'
+    #  variable to be null. We check, and if range is null, we move to the next
+    #  iteration of the loop (i.e. the next spectrum).
+    if {{[string trim $range] == ""}} {{
+        continue
+    }}
+
     # Calculates the number of channels in the range
     set num_chan [expr [lindex $range 1] - [lindex $range 0]]
     # Performs a check to see if the number of channels is greater than the minimum requirement, and

--- a/xga/xspec_scripts/general_xspec_fit.xcm
+++ b/xga/xspec_scripts/general_xspec_fit.xcm
@@ -1,5 +1,5 @@
 #  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (david.turner@sussex.ac.uk) 26/02/2021, 10:03. Copyright (c) David J Turner
+#  Last modified by David J Turner (djturner@umbc.edu) 10/12/2025, 09:39. Copyright (c) The Contributors
 
 # This XSPEC script template requires quite a few parameters to be filled in, using the Python formatting
 #  syntax. This *should* act as a general script for model combinations, so long as the formatted


### PR DESCRIPTION
We've experienced some mysterious seg faults with low quality spectra, particularly from eRASS data, that I hypothesised were to do with model declaration failing when there were 0 or 1 noticed channels.

The spectrum checking part of the script did check for a minimum number of noticed channels, but it was after a model was declared (which seems to be the seg fault point), and the check was only performed if spectrum checking was enabled by the user and for the model.

Now the check is always performed, and is used to screen out spectra before we get anywhere near a model.

Another, actually much more significant change in terms of lines altered in the code base, is that I went through the generate.esass.spec._spec_cmds function, neatened it up a bunch, avoided some potential pitfalls with variables in an internal function shadowing names in the outer scope, and added better support for eSASS4DR1.