### PR TITLE
Added a functional `general_smooth` function to imagetools

### DIFF
--- a/docs/source/xga.imagetools.rst
+++ b/docs/source/xga.imagetools.rst
@@ -25,4 +25,11 @@ imagetools.psf module
    :undoc-members:
    :show-inheritance:
 
+imagetools.smooth module
+---------------------
+
+.. automodule:: xga.imagetools.smooth
+   :members:
+   :undoc-members:
+   :show-inheritance:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,17 @@ export XGA_CONFIG_DIR=tests/test_data/config/
 python -m unittest discover -s tests -t . 
 ```
 
+**Note: You can add `-v` to the end of the above command to see the test names as they are run.**
+
+## Running specific tests
+
+For example: 
+
+```
+export XGA_CONFIG_DIR=tests/test_data/config/
+python -m unittest -v tests/test_products/test_events.py -k "TestEventListImageGeneration.check_missions_evt_init_image_gen" 
+```
+
 ## Running with coverage
 
 ```
@@ -24,4 +35,15 @@ coverage report
 
 ```
 coverage html
+```
+
+## Running specific tests with coverage
+
+Note that this will produce misleading coverage results at the XGA module level, as only a subset of
+tests are being run. It does help to see coverage of the parts of XGA that are being probed by the
+specific test(s) being run, however.
+
+```
+export XGA_CONFIG_DIR=tests/test_data/config/
+coverage run -m unittest -v tests/test_products/test_events.py -k "TestEventListImageGeneration.check_missions_evt_init_image_gen" 
 ```

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:46 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:47 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -38,7 +38,6 @@ class TestGeneralSmoothFunction(unittest.TestCase):
         with self.assertRaises(ValueError, msg="The 'general_smooth' function failed to "
                                                "raise an exception when passed a 1D kernel."):
             general_smooth(self.demo_im, cur_kern)
-
 
     def test_smooth_image(self):
         """Checks the general_smooth function by running on the demo image with various configurations."""

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:27 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:23 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -9,7 +9,7 @@ from astropy.convolution import Gaussian2DKernel, Gaussian1DKernel
 from astropy.units import Quantity
 
 from xga.imagetools import general_smooth
-from xga.products.phot import Image
+from xga.products.phot import Image, ExpMap, RateMap
 from .. import MISC_OUTPUT_TESTS
 
 
@@ -25,9 +25,21 @@ class TestGeneralSmoothFunction(unittest.TestCase):
         #  internet connection, then there will be artificial failures.
         cls.demo_im_url = ("https://heasarc.gsfc.nasa.gov/FTP/xmm/data/rev0/0843441101/"
                            "PPS/P0843441101M1S001IMAGE_8000.FTZ")
+        cls.demo_ex_url = ("https://heasarc.gsfc.nasa.gov/FTP/xmm/data/rev0/0843441101/"
+                           "PPS/P0843441101M1S001EXPMP_8000.FTZ")
+
         # Set up the XGA Image we'll be testing on
         cls.demo_im = Image(cls.demo_im_url, "0843441101", "mos1", "", "",
-                            "", Quantity(0.2, 'keV'), Quantity(12., 'keV'), telescope='xmm')
+                            "", Quantity(0.2, 'keV'), Quantity(12., 'keV'),
+                            telescope='xmm')
+
+        # Set up the XGA ExpMap we'll use to make a RateMap
+        cls.demo_ex = ExpMap(cls.demo_ex_url, "0843441101", "mos1", "", "",
+                            "", Quantity(0.2, 'keV'), Quantity(12., 'keV'),
+                            telescope='xmm')
+
+        # And then the RateMap itself
+        cls.demo_rt = RateMap(cls.demo_im, cls.demo_ex)
 
     def test_1D_kernel_fail(self):
         """Tests that a 1D Gaussian kernel triggers an exception."""
@@ -78,6 +90,49 @@ class TestGeneralSmoothFunction(unittest.TestCase):
             mask[270:378, 270:378] = 1
             masked_smth_im = general_smooth(self.demo_im, cur_kern, mask=mask)
             masked_smth_im.save_view(os.path.join(test_out_path, "masked_smooth.png"))
+
+    def test_smooth_ratemap_image(self):
+        """
+        Checks the general_smooth function by running on the demo ratemap, using the
+        ratemap_smooth_im=True method.
+        """
+        # Set up an output directory for this test - visualizations of the ratemaps will
+        #  be written to disk there as PNGs.
+        test_out_path = os.path.join(MISC_OUTPUT_TESTS, self.id())
+        os.makedirs(test_out_path, exist_ok=True)
+
+        # Define a 2D Gaussian Kernel
+        cur_kern = Gaussian2DKernel(2)
+
+        # Now start various subtests using different configurations of the general_smooth function
+        with self.subTest(check="Default smoothing ratemap [im method]"):
+            # Just passing the image and smoothing kernel
+            def_smth_rt = general_smooth(self.demo_rt, cur_kern, ratemap_smooth_im=True)
+            # Save view as a PNG
+            def_smth_rt.save_view(os.path.join(test_out_path, "default_smooth_rt_im_method.png"))
+
+        # Using the FFT convolution method
+        with self.subTest(check="FFT smoothing ratemap [im method]"):
+            fft_smth_rt = general_smooth(self.demo_rt, cur_kern, fft=True, ratemap_smooth_im=True)
+            fft_smth_rt.save_view(os.path.join(test_out_path, "FFT_smooth_rt_im_method.png"))
+
+        # Switching off kernel renormalization
+        with self.subTest(check="Unnormalized kernel smoothing ratemap [im method]"):
+            nonorm_smth_rt = general_smooth(self.demo_rt, cur_kern, norm_kernel=False, ratemap_smooth_im=True)
+            nonorm_smth_rt.save_view(os.path.join(test_out_path, "nonorm_smooth_rt_im_method.png"))
+
+        # Switching off kernel renormalization
+        with self.subTest(check="Unnormalized kernel FFT smoothing ratemap [im method]"):
+            nonorm_fft_smth_rt = general_smooth(self.demo_rt, cur_kern, fft=True, norm_kernel=False,
+                                                ratemap_smooth_im=True)
+            nonorm_fft_smth_rt.save_view(os.path.join(test_out_path, "nonorm_fft_smooth_rt_im_method.png"))
+
+        # Applying a mask and smoothing
+        with self.subTest(check="Masked smoothing ratemap [im method]"):
+            mask = np.zeros(self.demo_rt.data.shape, dtype=int)
+            mask[270:378, 270:378] = 1
+            masked_smth_rt = general_smooth(self.demo_rt, cur_kern, mask=mask, ratemap_smooth_im=True)
+            masked_smth_rt.save_view(os.path.join(test_out_path, "masked_smooth_rt_im_method.png"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:23 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:27 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -26,7 +26,7 @@ class TestGeneralSmoothFunction(unittest.TestCase):
         cls.demo_im_url = ("https://heasarc.gsfc.nasa.gov/FTP/xmm/data/rev0/0843441101/"
                            "PPS/P0843441101M1S001IMAGE_8000.FTZ")
         cls.demo_ex_url = ("https://heasarc.gsfc.nasa.gov/FTP/xmm/data/rev0/0843441101/"
-                           "PPS/P0843441101M1S001EXPMP_8000.FTZ")
+                           "PPS/P0843441101M1S001EXPMAP8000.FTZ")
 
         # Set up the XGA Image we'll be testing on
         cls.demo_im = Image(cls.demo_im_url, "0843441101", "mos1", "", "",

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:47 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:57 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -73,8 +73,8 @@ class TestGeneralSmoothFunction(unittest.TestCase):
 
         # Applying a mask and smoothing
         with self.subTest(check="Masked smoothing"):
-            mask = np.zeros(self.demo_im.data.shape, dtype=bool)
-            mask[100:200, 100:200] = True
+            mask = np.zeros(self.demo_im.data.shape, dtype=int)
+            mask[270:378, 270:378] = 1
             masked_smth_im = general_smooth(self.demo_im, cur_kern, mask=mask)
             masked_smth_im.save_view(os.path.join(test_out_path, "masked_smooth.png"))
 

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,0 +1,83 @@
+#  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:46 PM. Copyright (c) The Contributors.
+
+import os
+import unittest
+
+import numpy as np
+from astropy.convolution import Gaussian2DKernel, Gaussian1DKernel
+from astropy.units import Quantity
+
+from xga.imagetools import general_smooth
+from xga.products.phot import Image
+from .. import MISC_OUTPUT_TESTS
+
+
+class TestGeneralSmoothFunction(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Exists to prepare the XGA Image instance we'll use to test `general_smooth(...)`."""
+        # Store the URL in a class attribute just in case
+        # Might want to reconsider how much I'm using remote data for tests of product
+        #  classes. If files move or the tests are running on a machine with no
+        #  internet connection, then there will be artificial failures.
+        cls.demo_im_url = ("https://heasarc.gsfc.nasa.gov/FTP/xmm/data/rev0/0843441101/"
+                           "PPS/P0843441101M1S001IMAGE_8000.FTZ")
+        # Set up the XGA Image we'll be testing on
+        cls.demo_im = Image(cls.demo_im_url, "0843441101", "mos1", "", "",
+                            "", Quantity(0.2, 'keV'), Quantity(12., 'keV'), telescope='xmm')
+
+    def test_1D_kernel_fail(self):
+        """Tests that a 1D Gaussian kernel triggers an exception."""
+        # Define a 1D kernel
+        cur_kern = Gaussian1DKernel(2)
+
+        # Now we call the smoothing function, which should reject this kernel, as 1D
+        #  kernels cannot be applied to 2D imaging data.
+        with self.assertRaises(ValueError, msg="The 'general_smooth' function failed to "
+                                               "raise an exception when passed a 1D kernel."):
+            general_smooth(self.demo_im, cur_kern)
+
+
+    def test_smooth_image(self):
+        """Checks the general_smooth function by running on the demo image with various configurations."""
+        # Set up an output directory for this test - visualizations of the images will
+        #  be written to disk there as PNGs.
+        test_out_path = os.path.join(MISC_OUTPUT_TESTS, self.id())
+        os.makedirs(test_out_path, exist_ok=True)
+
+        # Define a 2D Gaussian Kernel
+        cur_kern = Gaussian2DKernel(2)
+
+        # Now start various subtests using different configurations of the general_smooth function
+        with self.subTest(check="Default smoothing"):
+            # Just passing the image and smoothing kernel
+            def_smth_im = general_smooth(self.demo_im, cur_kern)
+            # Save view as a PNG
+            def_smth_im.save_view(os.path.join(test_out_path, "default_smooth.png"))
+
+        # Using the FFT convolution method
+        with self.subTest(check="FFT smoothing"):
+            fft_smth_im = general_smooth(self.demo_im, cur_kern, fft=True)
+            fft_smth_im.save_view(os.path.join(test_out_path, "FFT_smooth.png"))
+
+        # Switching off kernel renormalization
+        with self.subTest(check="Unnormalized kernel smoothing"):
+            nonorm_smth_im = general_smooth(self.demo_im, cur_kern, norm_kernel=False)
+            nonorm_smth_im.save_view(os.path.join(test_out_path, "nonorm_smooth.png"))
+
+        # Switching off kernel renormalization
+        with self.subTest(check="Unnormalized kernel FFT smoothing"):
+            nonorm_fft_smth_im = general_smooth(self.demo_im, cur_kern, fft=True, norm_kernel=False)
+            nonorm_fft_smth_im.save_view(os.path.join(test_out_path, "nonorm_fft_smooth.png"))
+
+        # Applying a mask and smoothing
+        with self.subTest(check="Masked smoothing"):
+            mask = np.zeros(self.demo_im.data.shape, dtype=bool)
+            mask[100:200, 100:200] = True
+            masked_smth_im = general_smooth(self.demo_im, cur_kern, mask=mask)
+            masked_smth_im.save_view(os.path.join(test_out_path, "masked_smooth.png"))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_imagetools/test_smooth.py
+++ b/tests/test_imagetools/test_smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 12:57 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:27 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -14,6 +14,7 @@ from .. import MISC_OUTPUT_TESTS
 
 
 class TestGeneralSmoothFunction(unittest.TestCase):
+    """A set of tests of XGA's `general_smooth` imagetools function."""
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_products/test_events.py
+++ b/tests/test_products/test_events.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/22/26, 3:29 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:26 PM. Copyright (c) The Contributors.
 
 import os
 import unittest
@@ -100,7 +100,7 @@ class TestEventListImageGeneration(unittest.TestCase):
     def check_missions_evt_init_image_gen(self, name):
         cur_info = TEST_EVTS[name]
 
-        # We'll do a sub-test of the base event list checks first - no sense
+        # We'll do a subtest of the base event list checks first - no sense
         #  having a separate test for this when we're loading them all anyway to attempt to
         #  make images.
         # Declare the event list from the S3 URI

--- a/xga/imagetools/__init__.py
+++ b/xga/imagetools/__init__.py
@@ -1,7 +1,7 @@
-#  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 20/02/2023, 14:04. Copyright (c) The Contributors
+#  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
+#  Last modified by David J Turner (djturner@umbc.edu) 7/22/26, 6:00 PM. Copyright (c) The Contributors.
 
 from .misc import pix_deg_scale, data_limits
-from .profile import ann_radii, radial_brightness, pizza_brightness, annular_mask
-
+from .profile import ann_radii, radial_brightness, annular_mask
+from .smooth import general_smooth
 

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:25 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:26 PM. Copyright (c) The Contributors.
 
 from typing import Union, Optional
 
@@ -85,7 +85,7 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
 
     # Now we figure out what exactly needs to be smoothed.
     # If the input product is an Image, then it is very straightforward - we just copy
-    #  the data array, and will apply smoothing to that
+    #  the data array and will apply smoothing to that
     if type(prod) == Image:
         data_to_smth = prod.data.copy()
 

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/22/26, 5:59 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 11:46 AM. Copyright (c) The Contributors.
 
 from typing import Union, Optional
 
@@ -14,11 +14,14 @@ from xga.products import Image, RateMap, ExpMap
 def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[np.ndarray] = None, fft: bool = False,
                    norm_kernel: bool = True, sm_im: bool = True, force_resmooth: bool = False) -> Union[Image, RateMap]:
     """
-    Simple function to apply (in theory) any Astropy smoothing to an XGA Image/RateMap and create a new smoothed
-    XGA data product. This general function will produce XGA Image and RateMap
-    objects from any instance of an Astropy Kernel, and if a RateMap is passed as the input then you may choose
-    whether to smooth the image component or the image/expmap (using sm_im); if you choose the former then the final
-    smoothed RateMap will be produced by dividing the smoothed Image by the original ExpMap.
+    Applies Astropy's smoothing kernels to instances of the XGA Image and RateMap classes, returning a new
+    instance of the same class with smoothing applied. If the input is a RateMap instance, then you may choose
+    whether to smooth the image component or the image/expmap (using sm_im); if you choose the former, then the
+    final smoothed RateMap will be produced by dividing the smoothed Image by the original ExpMap.
+
+    Note that, as this function acts directly on XGA data products rather than on XGA sources or samples, the
+    new XGA product instances it produces are NOT added to the storage structure of a source.The returned product
+    instance can be manually added to a source by calling the <source instance>.update_products(<return from this function>) method.
 
     :param Image/RateMap prod: The XGA Image/RateMap to be smoothed. If you pass a RateMap, please see the 'sm_im'
         argument for extra options.
@@ -26,7 +29,8 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     :param np.ndarray mask: A mask to apply to the data while smoothing (removing point source contaminants, for
         instance). The default is None, which means no mask is applied. This function expects a mask with 1s where
         the data you wish to keep is, and 0s where the data you wish to remove is - the style of mask produced by XGA.
-    :param bool fft: Should a fast fourier transform method be used for convolution. The default is False.
+    :param bool fft: If set to True, then a fast fourier transform method will be used for kernel convolution.
+        The default is False.
     :param bool norm_kernel: Whether to normalize the kernel to have a sum of one.
     :param bool sm_im: If a RateMap is passed, should the image component be smoothed rather than the actual
         RateMap. Default is True, where the Image will be smoothed and divided by the original ExpMap. If set
@@ -59,13 +63,6 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
         raise ProductGenerationError("Input XGA Image or RateMap has already been smoothed, and "
                                      "will not be smoothed again. To override this check you may pass "
                                      "`force_resmooth=True`.")
-
-    # We implemented the capability to parse an Astropy smoothing kernel into the information
-    #  we want to add to XGA Image class properties into a static method of the Image class.
-    # So we can just call the parse_smoothing method and pull the name and parameters of the
-    # kernel out
-    smooth_name, smooth_pars = Image.parse_smoothing(kernel)
-    smooth_pars_str = "_".join([str(k) + str(v) for k, v in smooth_pars.items()])
 
     # Now we figure out what exactly needs to be smoothed.
     # If the input product is an Image, then it is very straightforward - we just copy

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 11:46 AM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:25 PM. Copyright (c) The Contributors.
 
 from typing import Union, Optional
 
@@ -12,7 +12,9 @@ from xga.products import Image, RateMap, ExpMap
 
 
 def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[np.ndarray] = None, fft: bool = False,
-                   norm_kernel: bool = True, sm_im: bool = True, force_resmooth: bool = False) -> Union[Image, RateMap]:
+                   sm_im: bool = True, force_resmooth: bool = False, norm_kernel: bool = True, boundary: Union[str, None] = 'fill',
+                   fill_value: Union[int, float] = 0.0, nan_treatment: str = 'interpolate', preserve_nan: bool = False,
+                   normalization_zero_tol: Union[float, int] = 1e-8) -> Union[Image, RateMap]:
     """
     Applies Astropy's smoothing kernels to instances of the XGA Image and RateMap classes, returning a new
     instance of the same class with smoothing applied. If the input is a RateMap instance, then you may choose
@@ -31,15 +33,32 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
         the data you wish to keep is, and 0s where the data you wish to remove is - the style of mask produced by XGA.
     :param bool fft: If set to True, then a fast fourier transform method will be used for kernel convolution.
         The default is False.
-    :param bool norm_kernel: Whether to normalize the kernel to have a sum of one.
     :param bool sm_im: If a RateMap is passed, should the image component be smoothed rather than the actual
         RateMap. Default is True, where the Image will be smoothed and divided by the original ExpMap. If set
         to False, the resulting RateMap will be bodged, with the ExpMap all 1s on the sensor.
     :param bool force_resmooth: Force a second smoothing convolution on an already-smoothed Image/RateMap.
         Default is False, in which case an error will be raised if the `prod` input is already smoothed.
+    :param bool norm_kernel: Whether to normalize the kernel to have a sum of one, passed to the Astropy convolution
+        function's `norm_kernel` argument. Default is True.
+    :param Any boundary: A flag indicating how to handle boundaries, passed through to the Astropy convolution
+        function's `boundary` argument, see Astropy documentation. The default value is 'fill'.
+    :param float/int fill_value: The value to use outside the array when using` boundary='fill'`, passed through
+        to the Astropy convolution function's `fill_value` argument. The default value is 0.0.
+    :param str nan_treatment: The method that Astropy uses to handle NaNs in the input array, passed through
+        to the Astropy convolution function's `nan_treatment` argument, see Astropy documentation. The default value is 'interpolate'.
+    :param bool preserve_nan: After performing convolution, should pixels that were originally NaN again become NaN?
+        Pass through to the Astropy convolution function's `preserve_nan` argument. The default is False.
+    :param float/int normalization_zero_tol: The absolute tolerance on whether the kernel is different from zero. If
+        the kernel sums to zero to within this precision, it cannot be normalized. Passed through to the Astropy
+        convolution function's `normalization_zero_tol` argument. The default is 1e-8.
     :return: An XGA product with the smoothed Image or RateMap.
     :rtype: Image/RateMap
     """
+    # Yes, we know we could/should have used kwargs to pass through Astropy smoothing function
+    #  configuration. However, in this case we would rather have the docstring entries present in our
+    #  docstring, rather than not mentioning them or appending the convolution function's docstring
+    #  to ours at run time.
+
     # First off, we check the type of the product that has been passed in for smoothing
     if not isinstance(prod, Image) or type(prod) == ExpMap:
         raise TypeError("Only an XGA Image or RateMap instance can be passed to the 'prod' argument.")
@@ -95,9 +114,13 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     # We now apply the Astropy smoothing kernel to the data, using FFT or non-FFT methods depending
     #  on what the user specified in their call to this function
     if fft:
-        sm_data = convolve_fft(data_to_smth, kernel, normalize_kernel=norm_kernel, mask=mask)
+        sm_data = convolve_fft(data_to_smth, kernel, mask=mask, normalize_kernel=norm_kernel, boundary=boundary,
+                           fill_value=fill_value, nan_treatment=nan_treatment, preserve_nan=preserve_nan,
+                           normalization_zero_tol=normalization_zero_tol)
     else:
-        sm_data = convolve(data_to_smth, kernel, normalize_kernel=norm_kernel, mask=mask)
+        sm_data = convolve(data_to_smth, kernel, mask=mask, normalize_kernel=norm_kernel, boundary=boundary,
+                           fill_value=fill_value, nan_treatment=nan_treatment, preserve_nan=preserve_nan,
+                           normalization_zero_tol=normalization_zero_tol)
 
     # Now we construct the new XGA product instance that houses the smoothed data
     #  In the case of an Image being passed in, we make an image to send back out

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:08 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:17 PM. Copyright (c) The Contributors.
 
 from typing import Union, Optional
 
@@ -12,8 +12,9 @@ from xga.products import Image, RateMap, ExpMap
 
 
 def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[np.ndarray] = None, fft: bool = False,
-                   ratemap_smooth_im: bool = True, force_resmooth: bool = False, norm_kernel: bool = True, boundary: Union[str, None] = 'fill',
-                   fill_value: Union[int, float] = 0.0, nan_treatment: str = 'interpolate', preserve_nan: bool = False,
+                   ratemap_smooth_im: bool = True, force_resmooth: bool = False, norm_kernel: bool = True,
+                   boundary: Union[str, None] = 'fill', fill_value: Union[int, float] = 0.0,
+                   nan_treatment: str = 'interpolate', preserve_nan: bool = False,
                    normalization_zero_tol: Union[float, int] = 1e-8) -> Union[Image, RateMap]:
     """
     Applies Astropy's smoothing kernels to instances of the XGA Image and RateMap classes, returning a new

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 1:26 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:08 PM. Copyright (c) The Contributors.
 
 from typing import Union, Optional
 
@@ -12,7 +12,7 @@ from xga.products import Image, RateMap, ExpMap
 
 
 def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[np.ndarray] = None, fft: bool = False,
-                   sm_im: bool = True, force_resmooth: bool = False, norm_kernel: bool = True, boundary: Union[str, None] = 'fill',
+                   ratemap_smooth_im: bool = True, force_resmooth: bool = False, norm_kernel: bool = True, boundary: Union[str, None] = 'fill',
                    fill_value: Union[int, float] = 0.0, nan_treatment: str = 'interpolate', preserve_nan: bool = False,
                    normalization_zero_tol: Union[float, int] = 1e-8) -> Union[Image, RateMap]:
     """
@@ -33,7 +33,7 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
         the data you wish to keep is, and 0s where the data you wish to remove is - the style of mask produced by XGA.
     :param bool fft: If set to True, then a fast fourier transform method will be used for kernel convolution.
         The default is False.
-    :param bool sm_im: If a RateMap is passed, should the image component be smoothed rather than the actual
+    :param bool ratemap_smooth_im: If a RateMap is passed, should the image component be smoothed rather than the actual
         RateMap. Default is True, where the Image will be smoothed and divided by the original ExpMap. If set
         to False, the resulting RateMap will be bodged, with the ExpMap all 1s on the sensor.
     :param bool force_resmooth: Force a second smoothing convolution on an already-smoothed Image/RateMap.
@@ -92,7 +92,7 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     # In this case the user has passed a RateMap for smoothing and also requested that we
     #  directly smooth the count-rate array (as opposed to extracting the image array, smoothing
     #  that, then re-dividing by the exposure map).
-    elif type(prod) == RateMap and not sm_im:
+    elif type(prod) == RateMap and not ratemap_smooth_im:
         raise NotImplementedError("XGA RateMaps can currently only be constructed from separate "
                                   "Image and ExpMap instances, and as such a new RateMap cannot"
                                   "yet be created from a smoothed count-rate array.")
@@ -101,7 +101,7 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     # In this instance the user has passed a RateMap, but specified that we should smooth
     #  the IMAGE data, then create a new RateMap by dividing the smoothed image by the
     #  original exposure map.
-    elif type(prod) == RateMap and sm_im:
+    elif type(prod) == RateMap and ratemap_smooth_im:
         data_to_smth = prod.image.data.copy()
 
     # Catch all else statement, meant to raise a vaguely useful error if the user
@@ -131,12 +131,12 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
                         smoothed=True, smoothed_info=kernel)
 
     # User requested that the count-rate array of a RateMap be smoothed
-    elif type(prod) == RateMap and not sm_im:
+    elif type(prod) == RateMap and not ratemap_smooth_im:
         raise NotImplementedError("XGA RateMaps can't yet be constructed from a single count-rate array.")
 
     # User requested that the Image of a RateMap be smoothed, and a new RateMap constructed using
     #  the original exposure map.
-    elif type(prod) == RateMap and sm_im:
+    elif type(prod) == RateMap and ratemap_smooth_im:
         # Construct the Image instance
         sm_im_prod = Image({'data': sm_data, 'wcs': prod.radec_wcs, 'header': prod.header}, prod.obs_id,
                            prod.instrument, "", "", "", lo_en=prod.energy_bounds[0],

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,17 +1,13 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/17/26, 3:42 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/22/26, 5:59 PM. Copyright (c) The Contributors.
 
-import os
-from random import randint
 from typing import Union, Optional
 
 import numpy as np
-import pandas as pd
 from astropy.convolution import Kernel, convolve, convolve_fft
-from fitsio import FITS
 
-from exceptions import ProductGenerationError
 from xga import OUTPUT
+from xga.exceptions import ProductGenerationError, XGADeveloperError
 from xga.products import Image, RateMap, ExpMap
 
 
@@ -27,10 +23,10 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     :param Image/RateMap prod: The XGA Image/RateMap to be smoothed. If you pass a RateMap, please see the 'sm_im'
         argument for extra options.
     :param Kernel kernel: The kernel with which to smooth the input data. Should be an instance of an Astropy Kernel.
-    :param np.ndarray mask: A mask to apply to the data while smoothing (removing point source interlopers for
+    :param np.ndarray mask: A mask to apply to the data while smoothing (removing point source contaminants, for
         instance). The default is None, which means no mask is applied. This function expects a mask with 1s where
         the data you wish to keep is, and 0s where the data you wish to remove is - the style of mask produced by XGA.
-    :param bool fft: Should a fast fourier transform method be used for convolution, default is False.
+    :param bool fft: Should a fast fourier transform method be used for convolution. The default is False.
     :param bool norm_kernel: Whether to normalize the kernel to have a sum of one.
     :param bool sm_im: If a RateMap is passed, should the image component be smoothed rather than the actual
         RateMap. Default is True, where the Image will be smoothed and divided by the original ExpMap. If set
@@ -42,33 +38,19 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
     """
     # First off, we check the type of the product that has been passed in for smoothing
     if not isinstance(prod, Image) or type(prod) == ExpMap:
-        raise TypeError("This function can only smooth data if input in the form of an XGA Image/RateMap.")
+        raise TypeError("Only an XGA Image or RateMap instance can be passed to the 'prod' argument.")
 
     # Also need to check that the kernel has the right number of dimensions
     if len(kernel.shape) != 2:
-        raise ValueError("The smoothing kernel needs to be two-dimensional for application to "
-                         "XGA Image or RateMap instances data - e.g. an astropy.convolution.Gaussian2DKernel "
-                         "instance.")
+        raise ValueError("The smoothing kernel must be two-dimensional, e.g. an "
+                         "astropy.convolution.Gaussian2DKernel instance.")
 
-    # While we ask for masks in the style XGA produces (0s where you don't want data, 1s where you do), unfortunately
+    # While we ask for masks in the style XGA produces (0s where you don't want data, 1s where you do), unfortunately,
     #  the smoothing functions seem to want the opposite, so I'll quickly invert the mask here
     if mask is not None:
         mask[mask == 0] = -1
         mask[mask == 1] = 0
         mask[mask == -1] = 1
-
-    # Read in the inventory of products relevant to the input image/ratemap
-    # inven = pd.read_csv(OUTPUT + "{}/inventory.csv".format(prod.obs_id), dtype=str)
-
-    inp_stor_key = prod.storage_key
-
-    # TODO I DON'T UNDERSTAND WHY I DID THIS ORIGINALLY, AND HAVE COMMENTED IT OUT FOR
-    #  NOW
-    # This is what the Image storage_key method does, but I want to do it here so I can just read in an
-    #  existing image if possible, and not waste time convolving over again
-    # if prod.psf_corrected:
-    #     key += "_" + prod.psf_model + "_" + str(prod.psf_bins) + "_" + prod.psf_algorithm + \
-    #            str(prod.psf_iterations)
 
     # By default, we raise an error if the input product has already been smoothed, but
     #  we do also include an argument that allows the user to override the
@@ -78,124 +60,74 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[n
                                      "will not be smoothed again. To override this check you may pass "
                                      "`force_resmooth=True`.")
 
-    # Finally we add our information from the input kernel to the key, as the parse_smoothing method of Image is
-    #  static we can just make use of that
+    # We implemented the capability to parse an Astropy smoothing kernel into the information
+    #  we want to add to XGA Image class properties into a static method of the Image class.
+    # So we can just call the parse_smoothing method and pull the name and parameters of the
+    # kernel out
     smooth_name, smooth_pars = Image.parse_smoothing(kernel)
     smooth_pars_str = "_".join([str(k) + str(v) for k, v in smooth_pars.items()])
 
-    inp_stor_key = f"{inp_stor_key}_sm{smooth_name}_sp{smooth_pars_str}"
-
-    # rel_inven = inven[(inven['type'] == 'image')]
-    # This narrows down the inventory to images that have the exact same info key (with smoothing information in), as
-    #  the one we would create for the smoothed image we're making in this function. We'd only expect anything left
-    #  in rel_inven if someone has already run this exact smoothing on this exact image, in which case we'll just
-    #  retrieve that file
-    rel_inven = inven[(inven['info_key'] == key) & (inven['type'] == 'image')]
-
-    # Grabs certain information from the input product, primarily about what type it is, so we can infer where it
-    #  should live in the XGA storage directory structure
-    if prod.instrument == 'combined' or prod.obs_id == 'combined':
-        # The ObsID-Instrument string combinations in the input product
-        ois = [o + i for o in prod.obs_ids for i in prod.instruments[o]]
-
-        # Where the smoothed image will live/lives
-        final_dest = OUTPUT + "combined/"
-
-        # I want to check whether a file of this particular smoothing already exists, slightly more complicated
-        #  for combined images - its an ugly solution but I can't be bothered to make it nicer right now
-        # This variable describes if the file already exists
-        existing = False
-        # This is where a new file would live, but will be overwritten if a matching image can be found
-        final_name = "{{ri}}_{l}-{u}keVmerged_img.fits".format(l=lo_en.to('keV').value, u=hi_en.to('keV').value)
-        for row_ind, row in rel_inven.iterrows():
-            split_insts = row['insts'].split('/')
-            combo = [o + split_insts[o_ind] for o_ind, o in enumerate(row['obs_ids'].split('/'))]
-            if set(combo) == set(ois):
-                existing = True
-                final_name = row['file_name']
-                break
-    else:
-        final_dest = OUTPUT + prod.obs_id + "/"
-
-        # The filename of the expected smoothed image, it will be overwritten if one already exists
-        final_name = "{o}_{i}_{{ri}}_{l}-{u}keV_img.fits".format(l=lo_en.to('keV').value, u=hi_en.to('keV').value,
-                                                                 o=prod.obs_id, i=prod.instrument)
-
-        # Easier to check for existing matching files than for combined images
-        f_names = rel_inven[(rel_inven['obs_id'] == prod.obs_id) & (rel_inven['inst'] == prod.instrument)]['file_name']
-
-        if len(f_names) != 0:
-            final_name = f_names.values[0]
-            existing = True
-        else:
-            existing = False
-
-    # Now to get into it properly, if its an XGA product then we need to retrieve the data as an array. Only check
-    #  whether its an instance of Image as that is the superclass for RateMap as well.
-    if not existing and type(prod) == Image:
-        data = prod.data.copy()
-    elif not existing and type(prod) == RateMap and not sm_im:
-        raise NotImplementedError("I haven't yet made sure that the rest of XGA will like this.")
-        data = prod.data.copy()
-    elif not existing and type(prod) == RateMap and sm_im:
-        data = prod.image.data.copy()
-
-    # Now we see which type of convolution the user has requested - entirely down to their discretion
-    if not existing and not fft:
-        sm_data = convolve(data, kernel, normalize_kernel=norm_kernel, mask=mask)
-    elif not existing and fft:
-        sm_data = convolve_fft(data, kernel, normalize_kernel=norm_kernel, mask=mask)
-
-    # Now that Astropy has done the heavy lifting part of the smoothing, we save the image as an actual file, then
-    #  assemble the output XGA product
+    # Now we figure out what exactly needs to be smoothed.
+    # If the input product is an Image, then it is very straightforward - we just copy
+    #  the data array, and will apply smoothing to that
     if type(prod) == Image:
-        new_path = final_dest + final_name
-        # If the file didn't already exist, we need to actually save the smoothed array, otherwise we'll just read
-        #  the file in later
-        if not existing:
-            rand_ident = str(randint(0, int(100_000_000)))
-            # Makes absolutely sure that the random integer hasn't already been used
-            while any([str(rand_ident) in f for f in os.listdir(final_dest)]):
-                rand_ident = str(randint(0, int(100_000_000)))
+        data_to_smth = prod.data.copy()
 
-            # The final name of the new image file
-            final_name = final_name.format(ri=rand_ident)
-            new_path = final_dest + final_name
-
-            # Writes out the smoothed data to the fits file
-            with FITS(new_path, 'rw', clobber=True) as immo:
-                immo.write(sm_data, header=prod.header)
-
-        # Sets up the XGA product, regardless of whether its just been generated or it already
-        #  existed, the process is the same
-        sm_prod = Image(new_path, prod.obs_id, prod.instrument, "", "", "", prod.energy_bounds[0],
-                        prod.energy_bounds[1], "", smoothed=True, smoothed_info=kernel)
-
+    # In this case the user has passed a RateMap for smoothing and also requested that we
+    #  directly smooth the count-rate array (as opposed to extracting the image array, smoothing
+    #  that, then re-dividing by the exposure map).
     elif type(prod) == RateMap and not sm_im:
-        raise NotImplementedError("I haven't yet made sure that the rest of XGA will like this.")
+        raise NotImplementedError("XGA RateMaps can currently only be constructed from separate "
+                                  "Image and ExpMap instances, and as such a new RateMap cannot"
+                                  "yet be created from a smoothed count-rate array.")
+        data_to_smth = prod.data.copy()
+
+    # In this instance the user has passed a RateMap, but specified that we should smooth
+    #  the IMAGE data, then create a new RateMap by dividing the smoothed image by the
+    #  original exposure map.
     elif type(prod) == RateMap and sm_im:
-        raise NotImplementedError("I haven't yet made sure that the rest of XGA will like this.")
+        data_to_smth = prod.image.data.copy()
 
-    # Make sure the smoothed product source name is the same as the passed in product's
-    sm_prod.src_name = prod.src_name
-    # Generate a new inventory line from the smoothed product
-    new_line = sm_prod.inventory_entry
+    # Catch all else statement, meant to raise a vaguely useful error if the user
+    #  has passed some sub-class of Image that we don't directly support here.
+    else:
+        raise XGADeveloperError("Only Image and RateMap instances are directly supported, contact "
+                                "the developers if you wish for us to support a sub-class of the Image class.")
 
-    # Add the new product to the inventory, even if it already existed
-    inven = pd.concat([inven, new_line.to_frame().T], ignore_index=True)
-    # Drop any duplicates in the inventory, which corrects the extra added in the last step if the file
-    #  already existed
-    inven = inven.drop_duplicates(subset='file_name', keep='first', ignore_index=True)
-    # And save it
-    inven.to_csv(OUTPUT + "{}/inventory.csv".format(prod.obs_id), index=False)
+
+    # We now apply the Astropy smoothing kernel to the data, using FFT or non-FFT methods depending
+    #  on what the user specified in their call to this function
+    if fft:
+        sm_data = convolve_fft(data_to_smth, kernel, normalize_kernel=norm_kernel, mask=mask)
+    else:
+        sm_data = convolve(data_to_smth, kernel, normalize_kernel=norm_kernel, mask=mask)
+
+    # Now we construct the new XGA product instance that houses the smoothed data
+    #  In the case of an Image being passed in, we make an image to send back out
+    if type(prod) == Image:
+        sm_prod = Image({'data': sm_data, 'wcs': prod.radec_wcs, 'header': prod.header}, prod.obs_id,
+                        prod.instrument, "", "", "", lo_en=prod.energy_bounds[0],
+                        hi_en=prod.energy_bounds[1], telescope=prod.telescope, check_exists=False,
+                        smoothed=True, smoothed_info=kernel)
+
+    # User requested that the count-rate array of a RateMap be smoothed
+    elif type(prod) == RateMap and not sm_im:
+        raise NotImplementedError("XGA RateMaps can't yet be constructed from a single count-rate array.")
+
+    # User requested that the Image of a RateMap be smoothed, and a new RateMap constructed using
+    #  the original exposure map.
+    elif type(prod) == RateMap and sm_im:
+        # Construct the Image instance
+        sm_im_prod = Image({'data': sm_data, 'wcs': prod.radec_wcs, 'header': prod.header}, prod.obs_id,
+                           prod.instrument, "", "", "", lo_en=prod.energy_bounds[0],
+                           hi_en=prod.energy_bounds[1], telescope=prod.telescope, check_exists=False,
+                           smoothed=True, smoothed_info=kernel)
+
+        # Now we make a new RateMap instance using that smoothed image
+        sm_prod = RateMap(sm_im_prod, prod.expmap)
+
+    else:
+        raise XGADeveloperError("Only Image and RateMap instances are directly supported, contact "
+                                "the developers if you wish for us to support a sub-class of the Image class.")
 
     return sm_prod
-
-
-
-
-
-
-
-
-

--- a/xga/imagetools/smooth.py
+++ b/xga/imagetools/smooth.py
@@ -1,30 +1,31 @@
-#  This code is a part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (turne540@msu.edu) 24/07/2024, 16:16. Copyright (c) The Contributors
+#  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
+#  Last modified by David J Turner (djturner@umbc.edu) 7/17/26, 3:42 PM. Copyright (c) The Contributors.
 
 import os
 from random import randint
-from typing import Union
+from typing import Union, Optional
 
 import numpy as np
 import pandas as pd
 from astropy.convolution import Kernel, convolve, convolve_fft
 from fitsio import FITS
 
-from .. import OUTPUT
-from ..products import Image, RateMap, ExpMap
+from exceptions import ProductGenerationError
+from xga import OUTPUT
+from xga.products import Image, RateMap, ExpMap
 
 
-def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: np.ndarray = None, fft: bool = False,
-                   norm_kernel: bool = True, sm_im: bool = True) -> Union[Image, RateMap]:
+def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: Optional[np.ndarray] = None, fft: bool = False,
+                   norm_kernel: bool = True, sm_im: bool = True, force_resmooth: bool = False) -> Union[Image, RateMap]:
     """
-    Simple function to apply (in theory) any Astropy smoothing to an XGA Image/RateMap  and create a new smoothed
+    Simple function to apply (in theory) any Astropy smoothing to an XGA Image/RateMap and create a new smoothed
     XGA data product. This general function will produce XGA Image and RateMap
     objects from any instance of an Astropy Kernel, and if a RateMap is passed as the input then you may choose
     whether to smooth the image component or the image/expmap (using sm_im); if you choose the former then the final
     smoothed RateMap will be produced by dividing the smoothed Image by the original ExpMap.
 
-    :param Image/RateMap prod: The image/ratemap to be smoothed. If a RateMap is passed please see the 'sm_im'
-        parameter for extra options.
+    :param Image/RateMap prod: The XGA Image/RateMap to be smoothed. If you pass a RateMap, please see the 'sm_im'
+        argument for extra options.
     :param Kernel kernel: The kernel with which to smooth the input data. Should be an instance of an Astropy Kernel.
     :param np.ndarray mask: A mask to apply to the data while smoothing (removing point source interlopers for
         instance). The default is None, which means no mask is applied. This function expects a mask with 1s where
@@ -34,18 +35,20 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: np.ndarray
     :param bool sm_im: If a RateMap is passed, should the image component be smoothed rather than the actual
         RateMap. Default is True, where the Image will be smoothed and divided by the original ExpMap. If set
         to False, the resulting RateMap will be bodged, with the ExpMap all 1s on the sensor.
+    :param bool force_resmooth: Force a second smoothing convolution on an already-smoothed Image/RateMap.
+        Default is False, in which case an error will be raised if the `prod` input is already smoothed.
     :return: An XGA product with the smoothed Image or RateMap.
     :rtype: Image/RateMap
     """
-    raise NotImplementedError("This function is not fully implemented yet!")
-    # First off we check the type of the product that has been passed in for smoothing
+    # First off, we check the type of the product that has been passed in for smoothing
     if not isinstance(prod, Image) or type(prod) == ExpMap:
         raise TypeError("This function can only smooth data if input in the form of an XGA Image/RateMap.")
 
     # Also need to check that the kernel has the right number of dimensions
     if len(kernel.shape) != 2:
-        raise ValueError("The smoothing kernel needs to be two-dimensional for application to Image/RateMap data - "
-                         "Gaussian2DKernel for instance.")
+        raise ValueError("The smoothing kernel needs to be two-dimensional for application to "
+                         "XGA Image or RateMap instances data - e.g. an astropy.convolution.Gaussian2DKernel "
+                         "instance.")
 
     # While we ask for masks in the style XGA produces (0s where you don't want data, 1s where you do), unfortunately
     #  the smoothing functions seem to want the opposite, so I'll quickly invert the mask here
@@ -55,26 +58,32 @@ def general_smooth(prod: Union[Image, RateMap], kernel: Kernel, mask: np.ndarray
         mask[mask == -1] = 1
 
     # Read in the inventory of products relevant to the input image/ratemap
-    inven = pd.read_csv(OUTPUT + "{}/inventory.csv".format(prod.obs_id), dtype=str)
+    # inven = pd.read_csv(OUTPUT + "{}/inventory.csv".format(prod.obs_id), dtype=str)
 
-    lo_en, hi_en = prod.energy_bounds
-    key = "bound_{l}-{u}".format(l=float(lo_en.value), u=float(hi_en.value))
+    inp_stor_key = prod.storage_key
 
+    # TODO I DON'T UNDERSTAND WHY I DID THIS ORIGINALLY, AND HAVE COMMENTED IT OUT FOR
+    #  NOW
     # This is what the Image storage_key method does, but I want to do it here so I can just read in an
     #  existing image if possible, and not waste time convolving over again
-    if prod.psf_corrected:
-        key += "_" + prod.psf_model + "_" + str(prod.psf_bins) + "_" + prod.psf_algorithm + \
-               str(prod.psf_iterations)
+    # if prod.psf_corrected:
+    #     key += "_" + prod.psf_model + "_" + str(prod.psf_bins) + "_" + prod.psf_algorithm + \
+    #            str(prod.psf_iterations)
 
-    # I don't want to let people smooth an image that has already been smoothed, that seems daft
-    if prod.smoothed:
-        raise ValueError("You cannot smooth an already smoothed image")
+    # By default, we raise an error if the input product has already been smoothed, but
+    #  we do also include an argument that allows the user to override the
+    #  behavior and smooth again.
+    if prod.smoothed and not force_resmooth:
+        raise ProductGenerationError("Input XGA Image or RateMap has already been smoothed, and "
+                                     "will not be smoothed again. To override this check you may pass "
+                                     "`force_resmooth=True`.")
 
     # Finally we add our information from the input kernel to the key, as the parse_smoothing method of Image is
     #  static we can just make use of that
-    sm, sp = Image.parse_smoothing(kernel)
-    sp = "_".join([str(k) + str(v) for k, v in sp.items()])
-    key += "_sm{sm}_sp{sp}".format(sm=sm, sp=sp)
+    smooth_name, smooth_pars = Image.parse_smoothing(kernel)
+    smooth_pars_str = "_".join([str(k) + str(v) for k, v in smooth_pars.items()])
+
+    inp_stor_key = f"{inp_stor_key}_sm{smooth_name}_sp{smooth_pars_str}"
 
     # rel_inven = inven[(inven['type'] == 'image')]
     # This narrows down the inventory to images that have the exact same info key (with smoothing information in), as

--- a/xga/products/phot.py
+++ b/xga/products/phot.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 11:14 AM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 3:08 PM. Copyright (c) The Contributors.
 
 import os
 from copy import deepcopy
@@ -2880,7 +2880,12 @@ class RateMap(Image):
             raise RateMapPairError("The energy bounds of xga_image ({0}) and xga_expmap ({1}) "
                                    "do not match".format(xga_image.energy_bounds, xga_expmap.energy_bounds))
 
-        super().__init__(xga_image.path, xga_image.obs_id, xga_image.instrument, xga_image.unprocessed_stdout,
+        # This path nonsense is to support the smoothing of RateMaps with general_smooth(..., ratemap_smooth_im=True) and
+        #  will become unnecessary once the RateMap/wider 2D data product redesign is implemented.
+        pass_path = xga_image.path if xga_image.path is not None else xga_expmap.path
+
+        # Call the superclass's init.
+        super().__init__(pass_path, xga_image.obs_id, xga_image.instrument, xga_image.unprocessed_stdout,
                          xga_image.unprocessed_stderr, "", xga_image.energy_bounds[0], xga_image.energy_bounds[1],
                          telescope=xga_image.telescope, check_exists=False)
         self._prod_type = "ratemap"
@@ -3614,7 +3619,7 @@ class RateMap(Image):
         self._matched_regions = self._process_matched_regions(new_reg)
 
         # This is the only part that's different from the implementation in the superclass. Here we make sure that
-        #  the same attribute is set for the Image, so if the user were to access the image from the RateMap
+        #  the same attribute is set for the Image, so if the user was to access the image from the RateMap
         #  they would still see any regions that have been added. No doubt there is a more elegant solution but this
         #  is what you're getting right now because I am exhausted
         self._im_obj.matched_regions = new_reg

--- a/xga/products/phot.py
+++ b/xga/products/phot.py
@@ -1,9 +1,9 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/21/26, 5:23 PM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 10:58 AM. Copyright (c) The Contributors.
 
 import os
 from copy import deepcopy
-from typing import Tuple, List, Union, Dict
+from typing import Tuple, List, Union, Dict, Optional
 from warnings import warn
 
 import numpy as np
@@ -1282,16 +1282,20 @@ class Image(BaseProduct):
 
         return peak_conv, None
 
-    def get_view(self, ax: Axes, cross_hair: Quantity = None, mask: np.ndarray = None,
-                 chosen_points: np.ndarray = None, other_points: List[np.ndarray] = None, zoom_in: bool = False,
-                 manual_zoom_xlims: tuple = None, manual_zoom_ylims: tuple = None,
-                 radial_bins_pix: np.ndarray = np.array([]), back_bin_pix: np.ndarray = None,
+    def get_view(self, ax: Axes, cross_hair: Optional[Quantity] = None, mask: Optional[np.ndarray] = None,
+                 chosen_points: Optional[np.ndarray] = None, other_points: Optional[List[np.ndarray]] = None,
+                 zoom_in: bool = False, manual_zoom_xlims: Optional[Tuple[float, float]] = None,
+                 manual_zoom_ylims: Optional[Tuple[float, float]] = None,
+                 radial_bins_pix: np.ndarray = np.array([]), back_bin_pix: Optional[np.ndarray] = None,
                  stretch: BaseStretch = LogStretch(), mask_edges: bool = True, view_regions: bool = False,
-                 ch_thickness: float = 0.8, low_val_lim: float = None, upp_val_lim: float = None,
-                 custom_title: str = None) -> Axes:
+                 ch_thickness: Union[float, int] = 0.8, low_val_lim: Optional[Union[float, int]] = None,
+                 upp_val_lim: Optional[Union[float, int]] = None, custom_title: Optional[str] = None,
+                 color_map: str = 'gnuplot2') -> Axes:
         """
-        The method that creates and populates the view axes, separate from actual view so outside methods
-        can add a view to other matplotlib axes.
+        This method creates and populates the standard axes for the view() and save_view() methods.
+
+        Direct use of this method is encouraged in situations where you wish to modify standard
+        XGA Image/RateMap/ExpMap/etc. visualizations without recreating them from scratch.
 
         :param Axes ax: The matplotlib axes on which to show the image.
         :param Quantity cross_hair: An optional parameter that can be used to plot a cross hair at
@@ -1322,18 +1326,21 @@ class Image(BaseProduct):
         :param BaseStretch stretch: The astropy scaling to use for the image data, default is log.
         :param bool mask_edges: If viewing a RateMap, this variable will control whether the chip edges are masked
             to remove artificially bright pixels, default is True.
-        :param bool view_regions: If regions have been associated with this object (either on init or using
-            the 'regions' property setter, should they be displayed. Default is False.
-        :param float ch_thickness: The desired linewidth of the crosshair(s), can be useful to increase this in
-            certain circumstances. Default is 0.8.
+        :param bool view_regions: Controls whether regions are plotted on top of the visualization. Though only if
+            regions have been associated with this object (either on init or using the 'regions' property setter).
+            Default is False.
+        :param float ch_thickness: The desired linewidth of the crosshair(s). It can be useful to increase this to
+            improve visibility. Default is 0.8.
         :param float low_val_lim: This can be used to set a lower limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if low_val_lim is
-            not None, upp_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the minimum pixel value of the data array.
         :param float upp_val_lim: This can be used to set an upper limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if upp_val_lim is
-            not None, low_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the maximum pixel value of the data array.
         :param str custom_title: If set, this will overwrite the automatically generated title for this
             visualisation. Default is None.
+        :param str color_map: The name of the matplotlib colormap to use when visualizing the
+            Image/RateMap/ExpMap/etc. data. The default value is 'gnuplot2'.
         :return: A populated figure displaying the view of the data.
         :rtype: Axes
         """
@@ -1346,16 +1353,13 @@ class Image(BaseProduct):
         else:
             plot_data = self.data
 
-        # We check that the values that set manual value limits are legal, otherwise we throw an error
-        check_lim_arg = [low_val_lim is None, upp_val_lim is None]
-        if any(check_lim_arg) and not all(check_lim_arg):
-            raise ValueError("Either 'low_val_lim' and 'upp_val_lim' are both None, or both have values.")
-        elif not all(check_lim_arg) and low_val_lim >= upp_val_lim:
-            raise ValueError("The 'low_val_lim' argument must be lower than 'upp_val_lim'.")
-        elif not all(check_lim_arg):
-            interval = ManualInterval(low_val_lim, upp_val_lim)
-        else:
-            interval = MinMaxInterval()
+        if (low_val_lim is not None and upp_val_lim is not None) and low_val_lim >= upp_val_lim:
+            raise ValueError("If 'low_val_lim' and 'upp_val_lim' are passed, the 'low_val_lim' argument "
+                             "must be smaller than 'upp_val_lim'.")
+
+        # Define the internal - this essentially defaults to the MinMaxInterval if both low_val_lim
+        #  and upp_val_lim are set to None.
+        interval = ManualInterval(low_val_lim, upp_val_lim)
 
         # If we're showing a RateMap, then we're gonna apply an edge mask to remove all the artificially brightened
         #  pixels that we can - it makes the view look better
@@ -1378,7 +1382,7 @@ class Image(BaseProduct):
         elif self.telescope is not None:
             ident = f"{self.telescope} {ident}"
 
-        # Ugly nested if statement but oh well I'm in a hurry - if the custom title is None then we auto generate a
+        # Ugly nested if statement but oh well I'm in a hurry - if the custom title is None, then we auto generate a
         #  title - otherwise we use the custom title and don't add anything to it
         if custom_title is None:
             # Being slightly more permissive with not setting energy bounds; this approach makes sure we don't
@@ -1392,7 +1396,7 @@ class Image(BaseProduct):
             else:
                 title = "{i} {l}-{u}keV {t}".format(i=ident, l=lo_en_str, u=hi_en_str, t=self.type)
 
-            # Its helpful to be able to distinguish PSF corrected image/ratemaps from the title
+            # It's helpful to be able to distinguish PSF corrected image/ratemaps from the title
             if self.psf_corrected:
                 title += ' - PSF Corrected'
 
@@ -1405,9 +1409,9 @@ class Image(BaseProduct):
         ax.set_title(title)
 
         # As this is a very quick view method, users will not be offered a choice of scaling
-        #  There will be a more in depth way of viewing cluster data eventually
+        #  There will be a more in-depth way of viewing cluster data eventually
         norm = ImageNormalize(data=plot_data, interval=interval, stretch=stretch)
-        # I normalize with a log stretch, and use gnuplot2 colormap (pretty decent for clusters imo)
+        # I normalize with a log stretch and use gnuplot2 colormap
 
         # If we want to plot point clusters on the image, then we go here
         if chosen_points is not None:
@@ -1424,7 +1428,7 @@ class Image(BaseProduct):
             # For the case of a single coordinate
             if cross_hair.shape == (2,):
                 # Converts from whatever input coordinate to pixels
-                pix_coord = self.coord_conv(cross_hair, pix).value
+                pix_coord = self.coord_conv(cross_hair, 'pix').value
                 # Drawing the horizontal and vertical lines
                 ax.axvline(pix_coord[0], color="white", linewidth=ch_thickness)
                 ax.axhline(pix_coord[1], color="white", linewidth=ch_thickness)
@@ -1432,7 +1436,7 @@ class Image(BaseProduct):
             # For the case of two coordinate pairs
             elif cross_hair.shape == (2, 2):
                 # Converts from whatever input coordinate to pixels
-                pix_coord = self.coord_conv(cross_hair, pix).value
+                pix_coord = self.coord_conv(cross_hair, 'pix').value
 
                 # This draws the first crosshair
                 ax.axvline(pix_coord[0, 0], color="white", linewidth=ch_thickness)
@@ -1471,7 +1475,7 @@ class Image(BaseProduct):
                     ax.add_artist(out_artist)
 
         # Adds the actual image to the axis.
-        ax.imshow(plot_data, norm=norm, origin="lower", cmap="gnuplot2")
+        ax.imshow(plot_data, norm=norm, origin="lower", cmap=color_map)
 
         # If the user wants regions on the image, this is where they get added
         if view_regions:
@@ -1487,27 +1491,32 @@ class Image(BaseProduct):
 
         # This sets the limits of the figure depending on the options that have been passed in
         if zoom_in and manual_zoom_xlims is None and manual_zoom_ylims is None:
-            # I don't like doing local imports, but this is the easiest way
+            # An unfortunate local import
             from xga.imagetools import data_limits
+
+            # Uses an XGA function to find the x and y limits of where there are
+            #  non-zero entries in the current data array.
             x_lims, y_lims = data_limits(plot_data)
             ax.set_xlim(x_lims)
             ax.set_ylim(y_lims)
-        elif zoom_in and manual_zoom_xlims is not None and manual_zoom_ylims is not None:
+
+        # Here the user has passed manual x-limits, so we apply them
+        if zoom_in and manual_zoom_xlims is not None and manual_zoom_ylims is None:
             ax.set_xlim(manual_zoom_xlims)
-            ax.set_ylim(manual_zoom_ylims)
-        elif zoom_in and manual_zoom_xlims is not None and manual_zoom_ylims is None:
-            ax.set_xlim(manual_zoom_xlims)
-        elif zoom_in and manual_zoom_xlims is None and manual_zoom_ylims is not None:
+        # Same here but for manual y-limits
+        if zoom_in and manual_zoom_xlims is None and manual_zoom_ylims is not None:
             ax.set_ylim(manual_zoom_ylims)
 
         return ax
 
-    def view(self, cross_hair: Quantity = None, mask: np.ndarray = None, chosen_points: np.ndarray = None,
-             other_points: List[np.ndarray] = None, figsize: Tuple = (10, 8), zoom_in: bool = False,
-             manual_zoom_xlims: tuple = None, manual_zoom_ylims: tuple = None,
-             radial_bins_pix: np.ndarray = np.array([]), back_bin_pix: np.ndarray = None,
-             stretch: BaseStretch = LogStretch(), mask_edges: bool = True, view_regions: bool = False,
-             ch_thickness: float = 0.8, low_val_lim: float = None, upp_val_lim: float = None, custom_title: str = None):
+    def view(self, cross_hair: Optional[Quantity] = None, mask: Optional[np.ndarray] = None,
+             chosen_points: Optional[np.ndarray] = None, other_points: Optional[List[np.ndarray]] = None,
+             figsize: Tuple = (10, 8), zoom_in: bool = False, manual_zoom_xlims: Optional[tuple] = None,
+             manual_zoom_ylims: Optional[tuple] = None, radial_bins_pix: np.ndarray = np.array([]),
+             back_bin_pix: Optional[np.ndarray] = None, stretch: BaseStretch = LogStretch(),
+             mask_edges: bool = True, view_regions: bool = False, ch_thickness: Union[float, int] = 0.8,
+             low_val_lim: Optional[Union[float, int]] = None, upp_val_lim: Optional[Union[float, int]] = None,
+             custom_title: Optional[str] = None, color_map: str = 'gnuplot2'):
         """
         Powerful method to view this Image/RateMap/Expmap, with different options that can be used for eyeballing
         and producing figures for publication.
@@ -1532,25 +1541,30 @@ class Image(BaseProduct):
             lower limit, second the upper limit. Variable zoom_in must still be true for these limits
             to be applied.
         :param np.ndarray radial_bins_pix: Radii (in units of pixels) of annuli to plot on top of the image, will
-            only be triggered if a cross_hair coordinate is also specified and contains only one coordinate.
+            only be triggered if a cross_hair coordinate is also specified, as this acts as the central coordinate
+            of the annuli. If two cross-hair coordinates are specified, the first will be used as the centre.
         :param np.ndarray back_bin_pix: The inner and outer radii (in pixel units) of the annulus used to measure
-            the background value for a given profile, will only be triggered if a cross_hair coordinate is
-            also specified and contains only one coordinate.
+            the background value for a given profile, will only be triggered if a cross_hair coordinate is also
+            specified, as this acts as the central coordinate of the annuli. If two cross-hair coordinates are
+            specified, the first will be used as the centre.
         :param BaseStretch stretch: The astropy scaling to use for the image data, default is log.
         :param bool mask_edges: If viewing a RateMap, this variable will control whether the chip edges are masked
             to remove artificially bright pixels, default is True.
-        :param bool view_regions: If regions have been associated with this object (either on init or using
-            the 'regions' property setter, should they be displayed. Default is False.
-        :param float ch_thickness: The desired linewidth of the crosshair(s), can be useful to increase this in
-            certain circumstances. Default is 0.8.
+        :param bool view_regions: Controls whether regions are plotted on top of the visualization. Though only if
+            regions have been associated with this object (either on init or using the 'regions' property setter).
+            Default is False.
+        :param float ch_thickness: The desired linewidth of the crosshair(s). It can be useful to increase this to
+            improve visibility. Default is 0.8.
         :param float low_val_lim: This can be used to set a lower limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if low_val_lim is
-            not None, upp_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the minimum pixel value of the data array.
         :param float upp_val_lim: This can be used to set an upper limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if upp_val_lim is
-            not None, low_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the maximum pixel value of the data array.
         :param str custom_title: If set, this will overwrite the automatically generated title for this
             visualisation. Default is None.
+        :param str color_map: The name of the matplotlib colormap to use when visualizing the
+            Image/RateMap/ExpMap/etc. data. The default value is 'gnuplot2'.
         """
 
         # Create figure object
@@ -1559,7 +1573,7 @@ class Image(BaseProduct):
         ax = plt.gca()
         ax = self.get_view(ax, cross_hair, mask, chosen_points, other_points, zoom_in, manual_zoom_xlims,
                            manual_zoom_ylims, radial_bins_pix, back_bin_pix, stretch, mask_edges, view_regions,
-                           ch_thickness, low_val_lim, upp_val_lim, custom_title)
+                           ch_thickness, low_val_lim, upp_val_lim, custom_title, color_map)
         cbar = plt.colorbar(ax.images[0])
         cbar.ax.set_ylabel(self.data_unit.to_string('latex'), fontsize=15)
         plt.tight_layout()
@@ -1570,13 +1584,14 @@ class Image(BaseProduct):
         # Wipe the figure
         plt.close("all")
 
-    def save_view(self, save_path: str, cross_hair: Quantity = None, mask: np.ndarray = None,
-                  chosen_points: np.ndarray = None, other_points: List[np.ndarray] = None, figsize: Tuple = (10, 8),
-                  zoom_in: bool = False, manual_zoom_xlims: tuple = None, manual_zoom_ylims: tuple = None,
-                  radial_bins_pix: np.ndarray = np.array([]), back_bin_pix: np.ndarray = None,
-                  stretch: BaseStretch = LogStretch(), mask_edges: bool = True, view_regions: bool = False,
-                  ch_thickness: float = 0.8, low_val_lim: float = None, upp_val_lim: float = None,
-                  custom_title: str = None):
+    def save_view(self, save_path: str, cross_hair: Optional[Quantity] = None, mask: Optional[np.ndarray] = None,
+                  chosen_points: Optional[np.ndarray] = None, other_points: Optional[List[np.ndarray]] = None,
+                  figsize: Tuple = (10, 8), zoom_in: bool = False, manual_zoom_xlims: Optional[tuple] = None,
+                  manual_zoom_ylims: Optional[tuple] = None, radial_bins_pix: np.ndarray = np.array([]),
+                  back_bin_pix: Optional[np.ndarray] = None, stretch: BaseStretch = LogStretch(),
+                  mask_edges: bool = True, view_regions: bool = False, ch_thickness: Union[float, int] = 0.8,
+                  low_val_lim: Optional[Union[float, int]] = None, upp_val_lim: Optional[Union[float, int]] = None,
+                  custom_title: Optional[str] = None, color_map: str = 'gnuplot2'):
         """
         This is entirely equivalent to the view() method, but instead of displaying the view it will save it to
         a path of your choosing.
@@ -1602,25 +1617,30 @@ class Image(BaseProduct):
             lower limit, second the upper limit. Variable zoom_in must still be true for these limits
             to be applied.
         :param np.ndarray radial_bins_pix: Radii (in units of pixels) of annuli to plot on top of the image, will
-            only be triggered if a cross_hair coordinate is also specified and contains only one coordinate.
+            only be triggered if a cross_hair coordinate is also specified, as this acts as the central coordinate
+            of the annuli. If two cross-hair coordinates are specified, the first will be used as the centre.
         :param np.ndarray back_bin_pix: The inner and outer radii (in pixel units) of the annulus used to measure
-            the background value for a given profile, will only be triggered if a cross_hair coordinate is
-            also specified and contains only one coordinate.
+            the background value for a given profile, will only be triggered if a cross_hair coordinate is also
+            specified, as this acts as the central coordinate of the annuli. If two cross-hair coordinates are
+            specified, the first will be used as the centre.
         :param BaseStretch stretch: The astropy scaling to use for the image data, default is log.
         :param bool mask_edges: If viewing a RateMap, this variable will control whether the chip edges are masked
             to remove artificially bright pixels, default is True.
-        :param bool view_regions: If regions have been associated with this object (either on init or using
-            the 'regions' property setter, should they be displayed. Default is False.
-        :param float ch_thickness: The desired linewidth of the crosshair(s), can be useful to increase this in
-            certain circumstances. Default is 0.8.
+        :param bool view_regions: Controls whether regions are plotted on top of the visualization. Though only if
+            regions have been associated with this object (either on init or using the 'regions' property setter).
+            Default is False.
+        :param float ch_thickness: The desired linewidth of the crosshair(s). It can be useful to increase this to
+            improve visibility. Default is 0.8.
         :param float low_val_lim: This can be used to set a lower limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if low_val_lim is
-            not None, upp_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the minimum pixel value of the data array.
         :param float upp_val_lim: This can be used to set an upper limit for the value range across which an image
-            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, and if upp_val_lim is
-            not None, low_val_lim must be as well.
+            is scaled and normalised (i.e. a ManualInterval from Astropy). The default is None, in which case
+            the value will be automatically set to the maximum pixel value of the data array.
         :param str custom_title: If set, this will overwrite the automatically generated title for this
             visualisation. Default is None.
+        :param str color_map: The name of the matplotlib colormap to use when visualizing the
+            Image/RateMap/ExpMap/etc. data. The default value is 'gnuplot2'.
         """
 
         # Create figure object
@@ -1631,7 +1651,7 @@ class Image(BaseProduct):
 
         ax = self.get_view(ax, cross_hair, mask, chosen_points, other_points, zoom_in, manual_zoom_xlims,
                            manual_zoom_ylims, radial_bins_pix, back_bin_pix, stretch, mask_edges, view_regions,
-                           ch_thickness, low_val_lim, upp_val_lim, custom_title)
+                           ch_thickness, low_val_lim, upp_val_lim, custom_title, color_map)
         cbar = plt.colorbar(ax.images[0], label=self.data_unit.to_string('latex'))
         cbar.ax.set_ylabel(self.data_unit.to_string('latex'), fontsize=15)
         plt.tight_layout()
@@ -2848,7 +2868,7 @@ class RateMap(Image):
             property. Default is None.
         """
         if type(xga_image) != Image or type(xga_expmap) != ExpMap:
-            raise TypeError("xga_image must be an XGA Image object, and xga_expmap must be an "
+            raise TypeError("'xga_image' must be an XGA Image object, and 'xga_expmap' must be an "
                             "XGA ExpMap object.")
 
         if xga_image.obs_id != xga_expmap.obs_id:

--- a/xga/products/phot.py
+++ b/xga/products/phot.py
@@ -1,5 +1,5 @@
 #  This code is part of X-ray: Generate and Analyse (XGA), a module designed for the XMM Cluster Survey (XCS).
-#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 10:58 AM. Copyright (c) The Contributors.
+#  Last modified by David J Turner (djturner@umbc.edu) 7/23/26, 11:14 AM. Copyright (c) The Contributors.
 
 import os
 from copy import deepcopy
@@ -1411,9 +1411,8 @@ class Image(BaseProduct):
         # As this is a very quick view method, users will not be offered a choice of scaling
         #  There will be a more in-depth way of viewing cluster data eventually
         norm = ImageNormalize(data=plot_data, interval=interval, stretch=stretch)
-        # I normalize with a log stretch and use gnuplot2 colormap
 
-        # If we want to plot point clusters on the image, then we go here
+        # If we want to plot point clusters on the image
         if chosen_points is not None:
             # Add the point cluster points
             ax.plot(chosen_points[:, 0], chosen_points[:, 1], '+', color='black', label="Chosen Point Cluster")


### PR DESCRIPTION
This function acts on XGA Image and RateMap instances, and allows the user to apply Astropy 2D smoothing kernels, returning new Image and RateMap instances. This PR will close issue #1545 

Some work on this will need to be done later (see issue #1546), but basic smoothing of Images and RateMaps is implemented.