### PR TITLE
fix(phot): py3.10-compatible f-string quoting

### DIFF
--- a/xga/products/phot.py
+++ b/xga/products/phot.py
@@ -232,7 +232,7 @@ class Image(BaseProduct):
             # And if it passes that we check that the instrument values are one of the allowed list
             elif any([e[1] not in ALLOWED_INST[telescope].values() for e in obs_inst_combs]):
                 raise ValueError(f"The allowed instruments for {telescope} are: "
-                                 f"{", ".join(ALLOWED_INST[telescope].values())}")
+                                 f"{', '.join(ALLOWED_INST[telescope].values())}")
 
         # This attribute stores the combinations of ObsID and instrument that make up combined images, if the
         #  current image is combined. This used to be instantiated in the init, but it is now lazy-loaded by


### PR DESCRIPTION
## Summary

`xga/products/phot.py:235` used a PEP 701 nested same-quote f-string:

```python
f"{", ".join(ALLOWED_INST[telescope].values())}"
```

Nested same-quote f-strings are only valid on Python 3.12+ (PEP 701). On Python 3.10 and 3.11 this is a `SyntaxError`, which makes `xga.products.phot` — and anything that imports it — fail to load. This contradicts the declared support matrix in `pyproject.toml`:

```toml
requires-python = ">=3.10"
```

## Fix

Swap the inner quotes from double to single so the f-string parses on all supported versions:

```python
f"{', '.join(ALLOWED_INST[telescope].values())}"
```

The output is identical (comma-space-joined values), and there is no behavior change on 3.12/3.13.

## Verification

- `python -m py_compile xga/products/phot.py` passes.
- `ast.parse` on the file succeeds.
- Only the single broken line is touched; no unrelated edits.

The full test suite requires XMM data products and astropy fixtures not available here, so I limited verification to the module compiling cleanly under the supported Python versions.

Closes #1560