### PR TITLE
Fixing issue #1564

### DIFF
--- a/xga/products/phot.py
+++ b/xga/products/phot.py
@@ -232,7 +232,7 @@ class Image(BaseProduct):
             # And if it passes that we check that the instrument values are one of the allowed list
             elif any([e[1] not in ALLOWED_INST[telescope].values() for e in obs_inst_combs]):
                 raise ValueError(f"The allowed instruments for {telescope} are: "
-                                 f"{", ".join(ALLOWED_INST[telescope].values())}")
+                                 f"{', '.join(ALLOWED_INST[telescope].values())}")
 
         # This attribute stores the combinations of ObsID and instrument that make up combined images, if the
         #  current image is combined. This used to be instantiated in the init, but it is now lazy-loaded by

--- a/xga/xspec/fit/_common.py
+++ b/xga/xspec/fit/_common.py
@@ -71,7 +71,7 @@ def _check_inputs(sources: Union[BaseSource, BaseSample], lum_en: Quantity, lo_e
 
     if abund_table not in ABUND_TABLES:
         raise ValueError(f"{abund_table} is not an XSPEC abundance table, allowed abundance tables are; "
-                         f"{", ".join(ABUND_TABLES)}.")
+                         f"{', '.join(ABUND_TABLES)}.")
 
     if not timeout.unit.is_equivalent('second'):
         raise UnitConversionError("The timeout quantity must be in units which can be converted to seconds, you have"


### PR DESCRIPTION
Only two instances of the syntax issue across the repo, which have now been changed to be compatible with Python < 3.13 