### PR TITLE
Fixing ClusterSample Declaration with peak finding on

### DIFF
--- a/xga/samples/extended.py
+++ b/xga/samples/extended.py
@@ -288,7 +288,7 @@ class ClusterSample(BaseSample):
                 if self._sources[n].disassociated:
                     try:
                         # This re-runs peak finding
-                        self._sources[n]._all_peaks(peak_find_method)
+                        self._sources[n]._all_peaks(peak_find_method, 'extended')
                         self._sources[n]._default_coord = self._sources[n].peak
 
                     except PeakConvergenceFailedError:


### PR DESCRIPTION
Adds source argument to _all_peaks() method in xga/samples/extended.py (line 291)